### PR TITLE
Persist charts to cosmos db

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      // Use IntelliSense to find out which attributes exist for C# debugging
+      // Use hover for the description of the existing attributes
+      // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+      "name": ".NET Core Launch (web)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      // If you have changed target frameworks, make sure to update the program path.
+      "program": "${workspaceFolder}/Finjector.Web/bin/Debug/net6.0/Finjector.Web.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/Finjector.Web",
+      "stopAtEntry": false,
+      // Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
+      "serverReadyAction": {
+        "action": "openExternally",
+        "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+      },
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "sourceFileMap": {
+        "/Views": "${workspaceFolder}/Views"
+      }
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/Finjector.Web/Finjector.Web.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "publish",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "publish",
+        "${workspaceFolder}/Finjector.Web/Finjector.Web.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "watch",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "run",
+        "--project",
+        "${workspaceFolder}/Finjector.Web/Finjector.Web.csproj"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}

--- a/Finjector.Core/Finjector.Core.csproj
+++ b/Finjector.Core/Finjector.Core.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.31.2" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
   

--- a/Finjector.Core/Finjector.Core.csproj
+++ b/Finjector.Core/Finjector.Core.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.31.2" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+  </ItemGroup>
+  
+</Project>

--- a/Finjector.Core/Models/Chart.cs
+++ b/Finjector.Core/Models/Chart.cs
@@ -1,0 +1,23 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Finjector.Core.Models;
+
+public class Chart
+{
+    // CosmosDb requires a lower case "id" property and makes use of Newtonsoft.Json
+    [Newtonsoft.Json.JsonProperty("id")]
+    [StringLength(36)]
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    [StringLength(10)]
+    public string IamId { get; set; } = "";
+    [StringLength(128)]
+    public string SegmentString { get; set; } = "";
+    [StringLength(200)]
+    public string DisplayName { get; set; } = "";
+    [StringLength(3)]
+    public string ChartType { get; set; } = "";
+}
+
+

--- a/Finjector.Core/Models/Chart.cs
+++ b/Finjector.Core/Models/Chart.cs
@@ -6,8 +6,6 @@ namespace Finjector.Core.Models;
 
 public class Chart
 {
-    // CosmosDb requires a lower case "id" property and makes use of Newtonsoft.Json
-    [Newtonsoft.Json.JsonProperty("id")]
     [StringLength(36)]
     public string Id { get; set; } = Guid.NewGuid().ToString();
     [StringLength(10)]

--- a/Finjector.Core/Models/ConnectionStrings.cs
+++ b/Finjector.Core/Models/ConnectionStrings.cs
@@ -1,9 +1,0 @@
-using System;
-
-namespace Finjector.Core.Models;
-
-public class ConnectionStrings
-{
-    public string CosmosDbEndpoint { get; set; } = "";
-}
-

--- a/Finjector.Core/Models/ConnectionStrings.cs
+++ b/Finjector.Core/Models/ConnectionStrings.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Finjector.Core.Models;
+
+public class ConnectionStrings
+{
+    public string CosmosDbEndpoint { get; set; } = "";
+}
+

--- a/Finjector.Core/Models/CosmosOptions.cs
+++ b/Finjector.Core/Models/CosmosOptions.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Finjector.Core.Models;
+
+public class CosmosOptions
+{
+    public string DatabaseName { get; set; } = "";
+}
+

--- a/Finjector.Core/Models/CosmosOptions.cs
+++ b/Finjector.Core/Models/CosmosOptions.cs
@@ -1,9 +1,13 @@
 using System;
+using Microsoft.Azure.Cosmos;
 
 namespace Finjector.Core.Models;
 
 public class CosmosOptions
 {
+    public string Endpoint { get; set; } = "";
+    public string Key { get; set; } = "";
     public string DatabaseName { get; set; } = "";
+    public bool UseGateway { get; set; } = false;
 }
 

--- a/Finjector.Core/Services/CosmosDbExtensions.cs
+++ b/Finjector.Core/Services/CosmosDbExtensions.cs
@@ -1,0 +1,25 @@
+using System;
+using Microsoft.Azure.Cosmos;
+
+namespace Finjector.Core.Services;
+
+public static class CosmosDbExtensions
+{
+    /// <summary>
+    /// Convert a feed iterator to IAsyncEnumerable
+    /// </summary>
+    /// <typeparam name="TModel"></typeparam>
+    /// <param name="setIterator"></param>
+    /// <returns></returns>
+    public static async IAsyncEnumerable<TModel> ToAsyncEnumerable<TModel>(this FeedIterator<TModel> setIterator)
+    {
+        while (setIterator.HasMoreResults)
+        {
+            foreach (var item in await setIterator.ReadNextAsync())
+            {
+                yield return item;
+            }
+        }
+    }
+}
+

--- a/Finjector.Core/Services/CosmosDbService.cs
+++ b/Finjector.Core/Services/CosmosDbService.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.ObjectModel;
+using Finjector.Core.Models;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Options;
+
+namespace Finjector.Core.Services;
+
+public interface ICosmosDbService
+{
+    Task<List<Chart>> GetCharts(string iamId);
+    Task<Chart> GetChart(string id, string iamId);
+    Task AddOrUpdateChart(Chart chart);
+    Task DeleteChart(string id, string iamId);
+}
+
+public class CosmosDbService : IDisposable, ICosmosDbService
+{
+    private readonly Lazy<Task<CosmosClient>> _cosmosClient;
+    private readonly CosmosOptions _cosmosOptions;
+
+    public const string ChartContainerName = "charts";
+
+
+    public CosmosDbService(IOptions<ConnectionStrings> connectionStrings, IOptions<CosmosOptions> cosmosOptions)
+    {
+        _cosmosOptions = cosmosOptions.Value;
+        _cosmosClient = new Lazy<Task<CosmosClient>>(async () =>
+        {
+            var client = new CosmosClient(connectionStrings.Value.CosmosDbEndpoint);
+            var database = await client.CreateDatabaseIfNotExistsAsync(_cosmosOptions.DatabaseName);
+            var container = await database.Database.CreateContainerIfNotExistsAsync(ChartContainerName, "/" + nameof(Chart.IamId));
+
+            return client;
+        });
+    }
+
+    public async Task<List<Chart>> GetCharts(string iamId)
+    {
+        var client = await _cosmosClient.Value;
+        var container = client.GetContainer(_cosmosOptions.DatabaseName, ChartContainerName);
+        var iterator = container.GetItemQueryIterator<Chart>(
+            new QueryDefinition("SELECT * FROM charts WHERE charts.IamId = @iamId")
+                .WithParameter("@iamId", iamId));
+
+        var charts = await iterator.ToAsyncEnumerable().ToListAsync();
+        return charts;
+    }
+
+    public async Task<Chart> GetChart(string id, string iamId)
+    {
+        var client = await _cosmosClient.Value;
+        var container = client.GetContainer(_cosmosOptions.DatabaseName, ChartContainerName);
+        var partitionKey = new PartitionKey(iamId);
+        var response = await container.ReadItemAsync<Chart>(id, partitionKey);
+
+        return response.Resource;
+    }
+
+    public async Task AddOrUpdateChart(Chart chart)
+    {
+        var client = await _cosmosClient.Value;
+        var container = client.GetContainer(_cosmosOptions.DatabaseName, ChartContainerName);
+        var partitionKey = new PartitionKey(chart.IamId);
+        var response = await container.UpsertItemAsync(chart, partitionKey);
+    }
+
+    public async Task DeleteChart(string id, string iamId)
+    {
+        var client = await _cosmosClient.Value;
+        var container = client.GetContainer(_cosmosOptions.DatabaseName, ChartContainerName);
+        var partitionKey = new PartitionKey(iamId);
+        var response = await container.DeleteItemAsync<Chart>(id, partitionKey);
+    }
+
+    public void Dispose()
+    {
+        if (_cosmosClient.IsValueCreated)
+        {
+            _cosmosClient.Value.Result.Dispose();
+        }
+    }
+
+}
+

--- a/Finjector.Core/Services/CosmosDbService.cs
+++ b/Finjector.Core/Services/CosmosDbService.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using Finjector.Core.Models;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Options;
+using Serilog;
 
 namespace Finjector.Core.Services;
 
@@ -71,6 +72,7 @@ public class CosmosDbService : IDisposable, ICosmosDbService
 
     public async Task AddOrUpdateChart(Chart chart)
     {
+        Log.Information("Adding or updating chart {ChartId}", chart.Id);
         var client = await _cosmosClient.Value;
         var container = client.GetContainer(_cosmosOptions.DatabaseName, ChartContainerName);
         var partitionKey = new PartitionKey(chart.IamId);
@@ -79,6 +81,7 @@ public class CosmosDbService : IDisposable, ICosmosDbService
 
     public async Task DeleteChart(string id, string iamId)
     {
+        Log.Information("Deleting chart {ChartId}", id);
         var client = await _cosmosClient.Value;
         var container = client.GetContainer(_cosmosOptions.DatabaseName, ChartContainerName);
         var partitionKey = new PartitionKey(iamId);

--- a/Finjector.Core/Services/CosmosDbService.cs
+++ b/Finjector.Core/Services/CosmosDbService.cs
@@ -72,7 +72,7 @@ public class CosmosDbService : IDisposable, ICosmosDbService
 
     public async Task AddOrUpdateChart(Chart chart)
     {
-        Log.Information("Adding or updating chart {ChartId}", chart.Id);
+        Log.Information("Adding or updating chart {ChartId} for iam {IamId}", chart.Id, chart.IamId);
         var client = await _cosmosClient.Value;
         var container = client.GetContainer(_cosmosOptions.DatabaseName, ChartContainerName);
         var partitionKey = new PartitionKey(chart.IamId);
@@ -81,7 +81,7 @@ public class CosmosDbService : IDisposable, ICosmosDbService
 
     public async Task DeleteChart(string id, string iamId)
     {
-        Log.Information("Deleting chart {ChartId}", id);
+        Log.Information("Deleting chart {ChartId} for iam {IamId}", id, iamId);
         var client = await _cosmosClient.Value;
         var container = client.GetContainer(_cosmosOptions.DatabaseName, ChartContainerName);
         var partitionKey = new PartitionKey(iamId);

--- a/Finjector.Web/ClientApp/src/pages/Landing.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Landing.tsx
@@ -9,7 +9,6 @@ import { useGetSavedCharts } from "../queries/storedChartQueries";
 const Landing = () => {
   const [search, setSearch] = React.useState("");
 
-  // TODO: add a loading state -- for now not needed because localstorage is synchronous
   const savedCharts = useGetSavedCharts();
 
   return (

--- a/Finjector.Web/ClientApp/src/queries/storedChartQueries.ts
+++ b/Finjector.Web/ClientApp/src/queries/storedChartQueries.ts
@@ -2,7 +2,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { v4 as uuidv4 } from "uuid";
 
 import { Chart, ChartType } from "../types";
-import { authenticatedFetch, doFetch } from "../util/api";
+import { doFetch } from "../util/api";
 
 // Using query functions here in case we change to async/stored stirngs later
 export const useGetSavedCharts = () =>
@@ -43,7 +43,7 @@ export const useSaveChart = () =>
   useMutation(async (chart: Chart) => {
     const savedChart: Chart = { ...chart, id: chart.id || uuidv4() };
 
-    await authenticatedFetch(`/api/charts/save`, {
+    await fetch(`/api/charts/save`, {
       method: "POST",
       body: JSON.stringify(savedChart),
       headers: {
@@ -59,7 +59,7 @@ export const useSaveChart = () =>
 // delete chart
 export const useRemoveChart = () =>
   useMutation(async (chart: Chart) => {
-    await authenticatedFetch(`/api/charts/delete/${chart.id}`, {
+    await fetch(`/api/charts/delete/${chart.id}`, {
       method: "DELETE",
     });
 

--- a/Finjector.Web/ClientApp/src/queries/storedChartQueries.ts
+++ b/Finjector.Web/ClientApp/src/queries/storedChartQueries.ts
@@ -2,28 +2,22 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { v4 as uuidv4 } from "uuid";
 
 import { Chart, ChartType } from "../types";
-import { doFetch } from "../util/api";
-
-const chartStorageKey = "STORED_CHARTS";
+import { authenticatedFetch, doFetch } from "../util/api";
 
 // Using query functions here in case we change to async/stored stirngs later
 export const useGetSavedCharts = () =>
-  useQuery(["charts", "me"], () =>
-    Promise.resolve<Chart[]>(
-      JSON.parse(localStorage.getItem(chartStorageKey) || "[]")
-    )
-  );
+  useQuery(["charts", "me"], async () => {
+    const charts = await doFetch<Chart[]>(fetch(`/api/charts/all`));
 
-// pull saved chart (from local storage) and also return hydrated chartData from server
+    return charts;
+  });
+
+// pull saved chart and return hydrated chartData from server
 export const useGetSavedChartWithData = (id: string) =>
   useQuery(
     ["charts", "saved", id],
     async () => {
-      var charts: Chart[] = JSON.parse(
-        localStorage.getItem(chartStorageKey) || "[]"
-      );
-
-      const chart = charts.find((chart) => chart.id === id) || null;
+      const chart = await doFetch<Chart>(fetch(`/api/charts/${id}`));
 
       if (chart) {
         // if we found the chart, load up segement values and validate
@@ -46,54 +40,28 @@ export const useGetSavedChartWithData = (id: string) =>
 
 // save new chart
 export const useSaveChart = () =>
-  useMutation((chart: Chart) => {
-    const charts: Chart[] = JSON.parse(
-      localStorage.getItem(chartStorageKey) || "[]"
-    );
+  useMutation(async (chart: Chart) => {
+    const savedChart: Chart = { ...chart, id: chart.id || uuidv4() };
 
-    let savedChart: Chart;
-
-    // if we have an id, update the existing chart
-    if (chart.id) {
-      const existingChart = charts.find((c) => c.id === chart.id);
-
-      if (existingChart) {
-        existingChart.displayName = chart.displayName;
-        existingChart.segmentString = chart.segmentString;
-        existingChart.chartType = chart.chartType;
-        savedChart = existingChart;
-      } else {
-        throw new Error("Chart not found with ID " + chart.id);
-      }
-    } else {
-      // otherwise, add a new chart
-      // add unique id to chart
-      const newChart = { ...chart, id: uuidv4() };
-
-      charts.push(newChart);
-      savedChart = newChart;
-    }
-
-    localStorage.setItem(chartStorageKey, JSON.stringify(charts));
+    await authenticatedFetch(`/api/charts/save`, {
+      method: "POST",
+      body: JSON.stringify(savedChart),
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+    });
 
     // return the saved chart
-    return Promise.resolve(savedChart);
+    return savedChart;
   });
 
 // delete chart
 export const useRemoveChart = () =>
-  useMutation((chart: Chart) => {
-    const charts: Chart[] = JSON.parse(
-      localStorage.getItem(chartStorageKey) || "[]"
-    );
+  useMutation(async (chart: Chart) => {
+    await authenticatedFetch(`/api/charts/delete/${chart.id}`, {
+      method: "DELETE",
+    });
 
-    const index = charts.findIndex((c) => c.id === chart.id);
-
-    if (index > -1) {
-      charts.splice(index, 1);
-    }
-
-    localStorage.setItem(chartStorageKey, JSON.stringify(charts));
-
-    return Promise.resolve(chart);
+    return chart;
   });

--- a/Finjector.Web/ClientApp/src/util/api.ts
+++ b/Finjector.Web/ClientApp/src/util/api.ts
@@ -7,38 +7,3 @@ export const doFetch = async <T>(fetchCall: Promise<Response>): Promise<T> => {
 
   return await res.json();
 };
-
-export const authenticatedFetch = async (
-  url: string,
-  init?: RequestInit,
-  additionalHeaders?: HeadersInit
-): Promise<any> => {
-  // ensure we have an XSRF token
-  var response = await fetch("/api/antiforgery/token", {
-    method: "GET",
-  });
-
-  if (!response.ok) {
-    throw new Error(`${response.status} ${response.statusText}`);
-  }
-
-  const xsrfToken = document.cookie
-    .split("; ")
-    .find((row) => row.startsWith("XSRF-TOKEN="))
-    ?.split("=")[1];
-
-  if (!xsrfToken) {
-    throw new Error("XSRF Token not found");
-  }
-
-  return fetch(url, {
-    ...init,
-    credentials: "include",
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-      "X-XSRF-TOKEN": xsrfToken,
-      ...additionalHeaders,
-    },
-  });
-};

--- a/Finjector.Web/ClientApp/src/util/api.ts
+++ b/Finjector.Web/ClientApp/src/util/api.ts
@@ -1,6 +1,4 @@
-export const doFetch = async <T>(
-  fetchCall: Promise<Response>
-): Promise<T> => {
+export const doFetch = async <T>(fetchCall: Promise<Response>): Promise<T> => {
   const res = await fetchCall;
 
   if (!res.ok) {
@@ -8,4 +6,39 @@ export const doFetch = async <T>(
   }
 
   return await res.json();
+};
+
+export const authenticatedFetch = async (
+  url: string,
+  init?: RequestInit,
+  additionalHeaders?: HeadersInit
+): Promise<any> => {
+  // ensure we have an XSRF token
+  var response = await fetch("/api/antiforgery/token", {
+    method: "GET",
+  });
+
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`);
+  }
+
+  const xsrfToken = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith("XSRF-TOKEN="))
+    ?.split("=")[1];
+
+  if (!xsrfToken) {
+    throw new Error("XSRF Token not found");
+  }
+
+  return fetch(url, {
+    ...init,
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "X-XSRF-TOKEN": xsrfToken,
+      ...additionalHeaders,
+    },
+  });
 };

--- a/Finjector.Web/Controllers/ChartsController.cs
+++ b/Finjector.Web/Controllers/ChartsController.cs
@@ -5,6 +5,7 @@ using System.Security.Claims;
 using Finjector.Web.Models;
 using Finjector.Core.Services;
 using Finjector.Core.Models;
+using Finjector.Web.Handlers;
 
 namespace Finjector.Web.Controllers;
 
@@ -15,20 +16,18 @@ namespace Finjector.Web.Controllers;
 public class ChartsController : ControllerBase
 {
     private readonly ICosmosDbService _cosmosDbService;
-    private readonly IIamIdService _iamIdService;
     public const string IamIdClaimType = "ucdPersonIAMID";
 
-    public ChartsController(ICosmosDbService cosmosDbService, IIamIdService iamIdService)
+    public ChartsController(ICosmosDbService cosmosDbService)
     {
         _cosmosDbService = cosmosDbService;
-        _iamIdService = iamIdService;
     }
 
     // fetch by id
     [HttpGet("{id}")]
     public async Task<IActionResult> GetChart(string id)
     {
-        var iamId = await _iamIdService.GetIamId();
+        var iamId = Request.HttpContext.User.FindFirstValue(IamIdClaimFallbackTransformer.ClaimType);
 
         if (iamId == null)
         {
@@ -48,7 +47,7 @@ public class ChartsController : ControllerBase
     [HttpGet("all")]
     public async Task<IActionResult> AllCharts()
     {
-        var iamId = await _iamIdService.GetIamId();
+        var iamId = Request.HttpContext.User.FindFirstValue(IamIdClaimFallbackTransformer.ClaimType);
 
         if (iamId == null)
         {
@@ -63,7 +62,7 @@ public class ChartsController : ControllerBase
     [HttpPost("save")]
     public async Task<IActionResult> SaveChart([FromBody] ChartViewModel chartViewModel)
     {
-        var iamId = await _iamIdService.GetIamId();
+        var iamId = Request.HttpContext.User.FindFirstValue(IamIdClaimFallbackTransformer.ClaimType);
 
         if (iamId == null)
         {
@@ -87,7 +86,7 @@ public class ChartsController : ControllerBase
     [HttpDelete("delete/{id}")]
     public async Task<IActionResult> DeleteChart(string id)
     {
-        var iamId = await _iamIdService.GetIamId();
+        var iamId = Request.HttpContext.User.FindFirstValue(IamIdClaimFallbackTransformer.ClaimType);
 
         if (iamId == null)
         {

--- a/Finjector.Web/Controllers/ChartsController.cs
+++ b/Finjector.Web/Controllers/ChartsController.cs
@@ -14,21 +14,21 @@ namespace Finjector.Web.Controllers;
 [Authorize]
 public class ChartsController : ControllerBase
 {
-    private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly ICosmosDbService _cosmosDbService;
+    private readonly IIamIdService _iamIdService;
     public const string IamIdClaimType = "ucdPersonIAMID";
 
-    public ChartsController(IHttpContextAccessor httpContextAccessor, ICosmosDbService cosmosDbService)
+    public ChartsController(ICosmosDbService cosmosDbService, IIamIdService iamIdService)
     {
-        _httpContextAccessor = httpContextAccessor;
         _cosmosDbService = cosmosDbService;
+        _iamIdService = iamIdService;
     }
 
     // fetch by id
     [HttpGet("{id}")]
     public async Task<IActionResult> GetChart(string id)
     {
-        var iamId = GetIamId();
+        var iamId = await _iamIdService.GetIamId();
 
         if (iamId == null)
         {
@@ -48,7 +48,7 @@ public class ChartsController : ControllerBase
     [HttpGet("all")]
     public async Task<IActionResult> AllCharts()
     {
-        var iamId = GetIamId();
+        var iamId = await _iamIdService.GetIamId();
 
         if (iamId == null)
         {
@@ -63,7 +63,7 @@ public class ChartsController : ControllerBase
     [HttpPost("save")]
     public async Task<IActionResult> SaveChart([FromBody] ChartViewModel chartViewModel)
     {
-        var iamId = GetIamId();
+        var iamId = await _iamIdService.GetIamId();
 
         if (iamId == null)
         {
@@ -87,7 +87,7 @@ public class ChartsController : ControllerBase
     [HttpDelete("delete/{id}")]
     public async Task<IActionResult> DeleteChart(string id)
     {
-        var iamId = GetIamId();
+        var iamId = await _iamIdService.GetIamId();
 
         if (iamId == null)
         {
@@ -97,11 +97,5 @@ public class ChartsController : ControllerBase
         await _cosmosDbService.DeleteChart(id, iamId);
 
         return Ok();
-    }
-
-    private string? GetIamId()
-    {
-        var iamId = _httpContextAccessor?.HttpContext?.User.FindFirstValue(IamIdClaimType);
-        return iamId;
     }
 }

--- a/Finjector.Web/Controllers/ChartsController.cs
+++ b/Finjector.Web/Controllers/ChartsController.cs
@@ -12,7 +12,6 @@ namespace Finjector.Web.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Authorize]
-[AutoValidateAntiforgeryToken]
 public class ChartsController : ControllerBase
 {
     private readonly IHttpContextAccessor _httpContextAccessor;

--- a/Finjector.Web/Controllers/ChartsController.cs
+++ b/Finjector.Web/Controllers/ChartsController.cs
@@ -1,0 +1,108 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+using Finjector.Web.Models;
+using Finjector.Core.Services;
+using Finjector.Core.Models;
+
+namespace Finjector.Web.Controllers;
+
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+[AutoValidateAntiforgeryToken]
+public class ChartsController : ControllerBase
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ICosmosDbService _cosmosDbService;
+    public const string IamIdClaimType = "ucdPersonIAMID";
+
+    public ChartsController(IHttpContextAccessor httpContextAccessor, ICosmosDbService cosmosDbService)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _cosmosDbService = cosmosDbService;
+    }
+
+    // fetch by id
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetChart(string id)
+    {
+        var iamId = GetIamId();
+
+        if (iamId == null)
+        {
+            return Unauthorized();
+        }
+
+        var chart = await _cosmosDbService.GetChart(id, iamId);
+
+        if (chart == null)
+        {
+            return NotFound();
+        }
+
+        return Ok(chart);
+    }
+
+    [HttpGet("all")]
+    public async Task<IActionResult> AllCharts()
+    {
+        var iamId = GetIamId();
+
+        if (iamId == null)
+        {
+            return Unauthorized();
+        }
+
+        var charts = await _cosmosDbService.GetCharts(iamId);
+
+        return Ok(charts);
+    }
+
+    [HttpPost("save")]
+    public async Task<IActionResult> SaveChart([FromBody] ChartViewModel chartViewModel)
+    {
+        var iamId = GetIamId();
+
+        if (iamId == null)
+        {
+            return Unauthorized();
+        }
+
+        var chart = new Chart()
+        {
+            Id = chartViewModel.Id,
+            IamId = iamId,
+            SegmentString = chartViewModel.SegmentString,
+            DisplayName = chartViewModel.DisplayName,
+            ChartType = chartViewModel.ChartType,
+        };
+
+        await _cosmosDbService.AddOrUpdateChart(chart);
+
+        return Ok();
+    }
+
+    [HttpDelete("delete/{id}")]
+    public async Task<IActionResult> DeleteChart(string id)
+    {
+        var iamId = GetIamId();
+
+        if (iamId == null)
+        {
+            return Unauthorized();
+        }
+
+        await _cosmosDbService.DeleteChart(id, iamId);
+
+        return Ok();
+    }
+
+    private string? GetIamId()
+    {
+        var iamId = _httpContextAccessor?.HttpContext?.User.FindFirstValue(IamIdClaimType);
+        return iamId;
+    }
+}

--- a/Finjector.Web/Finjector.Web.csproj
+++ b/Finjector.Web/Finjector.Web.csproj
@@ -27,6 +27,10 @@
     <None Include="$(SpaRoot)**" Exclude="$(SpaRoot)node_modules\**" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\finjector.core\finjector.core.csproj" />
+  </ItemGroup>
+
   <Target Name="DebugEnsureNodeEnv" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Debug' And !Exists('$(SpaRoot)node_modules') ">
     <!-- Ensure Node.js is installed -->
     <Exec Command="node --version" ContinueOnError="true">

--- a/Finjector.Web/Finjector.Web.csproj
+++ b/Finjector.Web/Finjector.Web.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="AggieEnterpriseApi" Version="0.2.134" />
+    <PackageReference Include="Ietws" Version="0.2.12" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="6.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />

--- a/Finjector.Web/Finjector.Web.csproj
+++ b/Finjector.Web/Finjector.Web.csproj
@@ -18,6 +18,10 @@
     <PackageReference Include="AggieEnterpriseApi" Version="0.2.134" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="6.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
+    <PackageReference Include="Serilog.Enrichers.ClientInfo" Version="1.2.0" />
+    <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
+    <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Finjector.Web/Finjector.Web.csproj
+++ b/Finjector.Web/Finjector.Web.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\finjector.core\finjector.core.csproj" />
+    <ProjectReference Include="..\Finjector.Core\Finjector.Core.csproj" />
   </ItemGroup>
 
   <Target Name="DebugEnsureNodeEnv" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Debug' And !Exists('$(SpaRoot)node_modules') ">

--- a/Finjector.Web/IamIdService.cs
+++ b/Finjector.Web/IamIdService.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Security.Claims;
+using Finjector.Web.Models;
+using Ietws;
+using Microsoft.Extensions.Options;
+
+namespace Finjector.Web
+{
+    public interface IIamIdService
+    {
+        Task<string?> GetIamId();
+    }
+
+    public class IamIdService : IIamIdService
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly AuthOptions _authOptions;
+
+        public const string IamIdClaimType = "ucdPersonIAMID";
+
+        public IamIdService(IHttpContextAccessor httpContextAccessor, IOptions<AuthOptions> authOptions)
+        {
+            _httpContextAccessor = httpContextAccessor;
+            _authOptions = authOptions.Value;
+        }
+
+        public async Task<string?> GetIamId()
+        {
+            var iamId = _httpContextAccessor.HttpContext?.User.FindFirstValue(IamIdClaimType);
+
+            if (!string.IsNullOrWhiteSpace(iamId))
+            {
+                return iamId;
+            }
+
+            return await GetIamIdFallback();
+        }
+
+        private async Task<string?> GetIamIdFallback()
+        {
+            var kerbId = _httpContextAccessor.HttpContext?.User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+            if (string.IsNullOrWhiteSpace(kerbId))
+            {
+                return null;
+            }
+
+            var clientws = new IetClient(_authOptions.IamKey);
+            var ucdKerbResult = await clientws.Kerberos.Search(KerberosSearchField.userId, kerbId);
+
+            if (ucdKerbResult.ResponseData.Results.Length == 0)
+            {
+                return null;
+            }
+
+            if (ucdKerbResult.ResponseData.Results.Length != 1)
+            {
+                var iamIds = ucdKerbResult.ResponseData.Results.Select(a => a.IamId).Distinct().ToArray();
+                var userIDs = ucdKerbResult.ResponseData.Results.Select(a => a.UserId).Distinct().ToArray();
+                if (iamIds.Length != 1 && userIDs.Length != 1)
+                {
+                    throw new Exception($"IAM issue with non unique values for kerbs: {string.Join(',', userIDs)} IAM: {string.Join(',', iamIds)}");
+                }
+            }
+
+            var ucdKerbPerson = ucdKerbResult.ResponseData.Results.First();
+            return ucdKerbPerson.IamId;
+        }
+    }
+}

--- a/Finjector.Web/Models/AuthOptions.cs
+++ b/Finjector.Web/Models/AuthOptions.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Finjector.Web.Models
+{
+    public class AuthOptions
+    {
+        public string Authority { get; set; } = "";
+        public string ClientId { get; set; } = "";
+        public string ClientSecret { get; set; } = "";
+        public string IamKey { get; set; } = "";
+    }
+}

--- a/Finjector.Web/Models/ChartViewModel.cs
+++ b/Finjector.Web/Models/ChartViewModel.cs
@@ -1,0 +1,18 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Finjector.Web.Models
+{
+    public class ChartViewModel
+    {
+        [StringLength(36)]
+        public string Id { get; set; } = "";
+        [StringLength(128)]
+        public string SegmentString { get; set; } = "";
+        [StringLength(200)]
+        public string DisplayName { get; set; } = "";
+        [StringLength(3)]
+        public string ChartType { get; set; } = "";
+    }
+}

--- a/Finjector.Web/Program.cs
+++ b/Finjector.Web/Program.cs
@@ -59,18 +59,6 @@ builder.Services.Configure<CosmosOptions>(builder.Configuration.GetSection("Cosm
 // It's an SDK best practice to use a singleton instance of CosmosClient
 builder.Services.AddSingleton<ICosmosDbService, CosmosDbService>();
 
-builder.Services.PostConfigure<ApiBehaviorOptions>(options =>
-{
-    var builtInFactory = options.InvalidModelStateResponseFactory;
-
-    options.InvalidModelStateResponseFactory = context =>
-    {
-        // Get an instance of ILogger (see below) and log accordingly.
-
-        return builtInFactory(context);
-    };
-});
-
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.

--- a/Finjector.Web/Program.cs
+++ b/Finjector.Web/Program.cs
@@ -13,6 +13,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.Configure<FinancialOptions>(builder.Configuration.GetSection("Financial"));
+builder.Services.Configure<CosmosOptions>(builder.Configuration.GetSection("CosmosDb"));
 
 builder.Services.AddControllersWithViews();
 
@@ -52,9 +53,6 @@ builder.Services.AddAuthentication(options =>
         NameClaimType = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"
     };
 });
-
-builder.Services.Configure<ConnectionStrings>(builder.Configuration.GetSection("ConnectionStrings"));
-builder.Services.Configure<CosmosOptions>(builder.Configuration.GetSection("CosmosDb"));
 
 // It's an SDK best practice to use a singleton instance of CosmosClient
 builder.Services.AddSingleton<ICosmosDbService, CosmosDbService>();

--- a/Finjector.Web/Program.cs
+++ b/Finjector.Web/Program.cs
@@ -53,9 +53,6 @@ builder.Services.AddAuthentication(options =>
     };
 });
 
-// Configure Antiforgery to use cookies
-builder.Services.AddAntiforgery(options => options.HeaderName = "X-XSRF-TOKEN");
-
 builder.Services.Configure<ConnectionStrings>(builder.Configuration.GetSection("ConnectionStrings"));
 builder.Services.Configure<CosmosOptions>(builder.Configuration.GetSection("CosmosDb"));
 
@@ -89,16 +86,6 @@ app.UseRouting();
 
 app.UseAuthentication();
 app.UseAuthorization();
-
-// Add endpoint that sets the XSRF-TOKEN cookie
-app.MapGet("api/antiforgery/token", (IAntiforgery forgeryService, HttpContext context) =>
-{
-    var tokens = forgeryService.GetAndStoreTokens(context);
-    context.Response.Cookies.Append("XSRF-TOKEN", tokens.RequestToken!,
-            new CookieOptions { HttpOnly = false });
-
-    return Results.Ok();
-}).RequireAuthorization();
 
 app.MapControllerRoute(
     name: "login",

--- a/Finjector.Web/Program.cs
+++ b/Finjector.Web/Program.cs
@@ -13,6 +13,7 @@ using Serilog;
 using Serilog.Events;
 using Serilog.Exceptions;
 using Serilog.Sinks.Elasticsearch;
+using Finjector.Web;
 
 #if DEBUG
 Serilog.Debugging.SelfLog.Enable(msg => Debug.WriteLine(msg));
@@ -54,6 +55,7 @@ try
     // Add services to the container.
     builder.Services.Configure<FinancialOptions>(builder.Configuration.GetSection("Financial"));
     builder.Services.Configure<CosmosOptions>(builder.Configuration.GetSection("CosmosDb"));
+    builder.Services.Configure<AuthOptions>(builder.Configuration.GetSection("Authentication"));
 
     builder.Services.AddControllersWithViews();
 
@@ -96,6 +98,8 @@ try
 
     // It's an SDK best practice to use a singleton instance of CosmosClient
     builder.Services.AddSingleton<ICosmosDbService, CosmosDbService>();
+    
+    builder.Services.AddScoped<IIamIdService, IamIdService>();
 
     var app = builder.Build();
 

--- a/Finjector.Web/Program.cs
+++ b/Finjector.Web/Program.cs
@@ -14,6 +14,8 @@ using Serilog.Events;
 using Serilog.Exceptions;
 using Serilog.Sinks.Elasticsearch;
 using Finjector.Web;
+using Microsoft.AspNetCore.Authentication;
+using Finjector.Web.Handlers;
 
 #if DEBUG
 Serilog.Debugging.SelfLog.Enable(msg => Debug.WriteLine(msg));
@@ -99,7 +101,8 @@ try
     // It's an SDK best practice to use a singleton instance of CosmosClient
     builder.Services.AddSingleton<ICosmosDbService, CosmosDbService>();
     
-    builder.Services.AddScoped<IIamIdService, IamIdService>();
+    // Add the IamId to claims if not provided by CAS
+    builder.Services.AddScoped<IClaimsTransformation, IamIdClaimFallbackTransformer>();
 
     var app = builder.Build();
 

--- a/Finjector.Web/Program.cs
+++ b/Finjector.Web/Program.cs
@@ -8,80 +8,132 @@ using Finjector.Core.Models;
 using Finjector.Core.Services;
 using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Mvc;
+using System.Diagnostics;
+using Serilog;
+using Serilog.Events;
+using Serilog.Exceptions;
+using Serilog.Sinks.Elasticsearch;
+
+#if DEBUG
+Serilog.Debugging.SelfLog.Enable(msg => Debug.WriteLine(msg));
+#endif
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-builder.Services.Configure<FinancialOptions>(builder.Configuration.GetSection("Financial"));
-builder.Services.Configure<CosmosOptions>(builder.Configuration.GetSection("CosmosDb"));
+var loggingSection = builder.Configuration.GetSection("Serilog");
 
-builder.Services.AddControllersWithViews();
+var loggerConfig = new LoggerConfiguration()
+    .MinimumLevel.Debug()
+    .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+    // .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning) // uncomment this to hide EF core general info logs
+    .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
+    .MinimumLevel.Override("System", LogEventLevel.Warning)
+    .Enrich.FromLogContext()
+    .Enrich.WithClientIp()
+    .Enrich.WithClientAgent()
+    .Enrich.WithExceptionDetails()
+    .Enrich.WithProperty("Application", loggingSection.GetValue<string>("AppName"))
+    .Enrich.WithProperty("AppEnvironment", loggingSection.GetValue<string>("Environment"))
+    .WriteTo.Console();
 
-builder.Services.AddHttpContextAccessor();
-
-builder.Services.AddAuthentication(options =>
+// add in elastic search sink if the uri is valid
+if (Uri.TryCreate(loggingSection.GetValue<string>("ElasticUrl"), UriKind.Absolute, out var elasticUri))
 {
-    options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-})
-.AddCookie(options =>
-{
-    options.LoginPath = new PathString("/Account/Login/");
-    options.Events.OnRedirectToLogin = (ctx) =>
+    loggerConfig.WriteTo.Elasticsearch(new ElasticsearchSinkOptions(elasticUri)
     {
-        // API requests shouldn't redirect to login
-        if (ctx.Request.Path.StartsWithSegments("/api") && ctx.Response.StatusCode == 200)
-            ctx.Response.StatusCode = 401;
-        else
-            ctx.Response.Redirect(ctx.RedirectUri);
-
-        return Task.CompletedTask;
-    };
-})
-.AddOpenIdConnect(oidc =>
-{
-    oidc.ClientId = builder.Configuration["Authentication:ClientId"];
-    oidc.ClientSecret = builder.Configuration["Authentication:ClientSecret"];
-    oidc.Authority = builder.Configuration["Authentication:Authority"];
-    oidc.ResponseType = OpenIdConnectResponseType.Code;
-    oidc.Scope.Add("openid");
-    oidc.Scope.Add("profile");
-    oidc.Scope.Add("email");
-    oidc.Scope.Add("ucdProfile");
-    oidc.Scope.Add("eduPerson");
-    oidc.TokenValidationParameters = new TokenValidationParameters
-    {
-        NameClaimType = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"
-    };
-});
-
-// It's an SDK best practice to use a singleton instance of CosmosClient
-builder.Services.AddSingleton<ICosmosDbService, CosmosDbService>();
-
-var app = builder.Build();
-
-// Configure the HTTP request pipeline.
-if (!app.Environment.IsDevelopment())
-{
-    // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
-    app.UseHsts();
+        IndexFormat = "aspnet-finjector-{0:yyyy.MM}"
+    });
 }
 
-app.UseHttpsRedirection();
-app.UseStaticFiles();
-app.UseRouting();
+Log.Logger = loggerConfig.CreateLogger();
 
-app.UseAuthentication();
-app.UseAuthorization();
+try
+{
+    Log.Information("Configuring web host");
 
-app.MapControllerRoute(
-    name: "login",
-    pattern: "Account/Login",
-    defaults: new { controller = "Account", action = "Login" });
+    // Add services to the container.
+    builder.Services.Configure<FinancialOptions>(builder.Configuration.GetSection("Financial"));
+    builder.Services.Configure<CosmosOptions>(builder.Configuration.GetSection("CosmosDb"));
 
-app.MapControllerRoute(
-    name: "api",
-    pattern: "/api/{controller}/{action=Index}/{id?}");
+    builder.Services.AddControllersWithViews();
 
-app.MapFallbackToFile("index.html");
+    builder.Services.AddHttpContextAccessor();
 
-app.Run();
+    builder.Services.AddAuthentication(options =>
+    {
+        options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+    })
+    .AddCookie(options =>
+    {
+        options.LoginPath = new PathString("/Account/Login/");
+        options.Events.OnRedirectToLogin = (ctx) =>
+        {
+            // API requests shouldn't redirect to login
+            if (ctx.Request.Path.StartsWithSegments("/api") && ctx.Response.StatusCode == 200)
+                ctx.Response.StatusCode = 401;
+            else
+                ctx.Response.Redirect(ctx.RedirectUri);
+
+            return Task.CompletedTask;
+        };
+    })
+    .AddOpenIdConnect(oidc =>
+    {
+        oidc.ClientId = builder.Configuration["Authentication:ClientId"];
+        oidc.ClientSecret = builder.Configuration["Authentication:ClientSecret"];
+        oidc.Authority = builder.Configuration["Authentication:Authority"];
+        oidc.ResponseType = OpenIdConnectResponseType.Code;
+        oidc.Scope.Add("openid");
+        oidc.Scope.Add("profile");
+        oidc.Scope.Add("email");
+        oidc.Scope.Add("ucdProfile");
+        oidc.Scope.Add("eduPerson");
+        oidc.TokenValidationParameters = new TokenValidationParameters
+        {
+            NameClaimType = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"
+        };
+    });
+
+    // It's an SDK best practice to use a singleton instance of CosmosClient
+    builder.Services.AddSingleton<ICosmosDbService, CosmosDbService>();
+
+    var app = builder.Build();
+
+    // Configure the HTTP request pipeline.
+    if (!app.Environment.IsDevelopment())
+    {
+        // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+        app.UseHsts();
+    }
+
+    app.UseHttpsRedirection();
+    app.UseStaticFiles();
+    app.UseRouting();
+
+    app.UseAuthentication();
+    app.UseAuthorization();
+
+    app.MapControllerRoute(
+        name: "login",
+        pattern: "Account/Login",
+        defaults: new { controller = "Account", action = "Login" });
+
+    app.MapControllerRoute(
+        name: "api",
+        pattern: "/api/{controller}/{action=Index}/{id?}");
+
+    app.MapFallbackToFile("index.html");
+
+    Log.Information("Starting web host");
+    app.Run();
+    return 0;
+}
+catch (Exception ex)
+{
+    Log.Fatal(ex, "Application start-up failed");
+    return 1;
+}
+finally
+{
+    Log.CloseAndFlush();
+}

--- a/Finjector.Web/appsettings.json
+++ b/Finjector.Web/appsettings.json
@@ -12,5 +12,8 @@
     "ClientId": "[external]",
     "ClientSecret": "[external]",
     "IamKey": "[External]"
+  },
+  "CosmosDb": {
+    "DatabaseName": "finjector"
   }
 }

--- a/Finjector.Web/appsettings.json
+++ b/Finjector.Web/appsettings.json
@@ -18,5 +18,10 @@
     "Key": "[External]",
     "DatabaseName": "finjector",
     "UseGateway": "false"
+  },
+  "Serilog": {
+    "AppName": "Finjector",
+    "Environment": "[External]",
+    "ElasticUrl": "[External]"
   }
 }

--- a/Finjector.Web/appsettings.json
+++ b/Finjector.Web/appsettings.json
@@ -14,6 +14,9 @@
     "IamKey": "[External]"
   },
   "CosmosDb": {
-    "DatabaseName": "finjector"
+    "Endpoint": "[External]",
+    "Key": "[External]",
+    "DatabaseName": "finjector",
+    "UseGateway": "false"
   }
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project is available for use by any UC Davis website as a convenient option
 
 [Follow this link to view a live example](https://ucdavis.github.io/finjector/).  Clicking on the "Lookup" button next to the chart string entry box will bring up the Finjector UI.
 
-You can then create a new GL or PPM account from scratch, or paste in an existing one.  We'll use local storage to remember prior choices, so if do the lookup again you can just press "Use" and it'll be inserted instantly.
+You can then create a new GL or PPM account from scratch, or paste in an existing one.  We keep track of prior choices, so if do the lookup again you can just press "Use" and it'll be inserted instantly.
 
 Try using the example PPM account listed below the input box, and choose "Create new chart from paste" to get started quickly.  If you build from scratch, PPM is suggested because there are only four fields, compared to 8 for GL.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ steps:
     publishWebProjects: true
     zipAfterPublish: false
     modifyOutputPath: false
-    projects: './Finjector.Web/Finjector.Web.csproj'
+    projects: '**/*.csproj'
     arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)/'
 
 - task: PublishBuildArtifacts@1

--- a/finjector.sln
+++ b/finjector.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.30114.105
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Finjector.Web", "Finjector.Web\Finjector.Web.csproj", "{27C1FF4F-E172-4D4E-BD20-6BE6EB2381BF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "finjector.core", "finjector.core\finjector.core.csproj", "{4890E411-D03E-4BA9-8C3B-D6E333F82C79}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +20,9 @@ Global
 		{27C1FF4F-E172-4D4E-BD20-6BE6EB2381BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{27C1FF4F-E172-4D4E-BD20-6BE6EB2381BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{27C1FF4F-E172-4D4E-BD20-6BE6EB2381BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4890E411-D03E-4BA9-8C3B-D6E333F82C79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4890E411-D03E-4BA9-8C3B-D6E333F82C79}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4890E411-D03E-4BA9-8C3B-D6E333F82C79}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4890E411-D03E-4BA9-8C3B-D6E333F82C79}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/finjector.sln
+++ b/finjector.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 16.0.30114.105
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Finjector.Web", "Finjector.Web\Finjector.Web.csproj", "{27C1FF4F-E172-4D4E-BD20-6BE6EB2381BF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "finjector.core", "finjector.core\finjector.core.csproj", "{4890E411-D03E-4BA9-8C3B-D6E333F82C79}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Finjector.Core", "Finjector.Core\Finjector.Core.csproj", "{4890E411-D03E-4BA9-8C3B-D6E333F82C79}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
I added elastic logging because cosmos db seems a bit finicky, or at least the local emulator does. It gave a 500 Internal Error about half of the times it was requested to create the db/container.

I added a `UseGateway` option, because the VPN firewall doesn't seem to allow `Direct` connections from dev machines to the Azure Cosmos instance, and debugging against the local emulator does not work with `Gateway` connections.