### PR TITLE
change edit page and paste pages to handle dynamic loads

### DIFF
--- a/Finjector.Web/ClientApp/src/App.tsx
+++ b/Finjector.Web/ClientApp/src/App.tsx
@@ -28,7 +28,8 @@ function App() {
           <Route path="/landing" element={<Landing />} />
           <Route path="/entry">
             <Route path="" element={<Entry />} />
-            <Route path=":id/:chart" element={<Entry />} />
+            <Route path=":chartSegmentString" element={<Entry />} />
+            <Route path=":id/:chartSegmentString" element={<Entry />} />
           </Route>
           <Route path="/paste" element={<Paste />} />
           <Route path="/selected/:id/:chart" element={<Selected />} />

--- a/Finjector.Web/ClientApp/src/pages/Entry.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Entry.tsx
@@ -21,6 +21,7 @@ import { useGetSavedChartWithData } from "../queries/storedChartQueries";
 import {
   fromGlSegmentString,
   fromPpmSegmentString,
+  isGlSegmentString,
 } from "../util/segmentValidation";
 import NameEntry from "../components/NameEntry";
 import { mapSegmentQueryData } from "../util/segmentMapping";
@@ -30,7 +31,7 @@ import { HomeLink } from "../components/HomeLink";
 import { ChartLoadingError } from "../components/ChartLoadingError";
 
 const Entry = () => {
-  const { id } = useParams();
+  const { id, chartSegmentString } = useParams();
 
   const savedChartQuery = useGetSavedChartWithData(id || "");
 
@@ -42,10 +43,20 @@ const Entry = () => {
   });
 
   // in progress chart data
-  const [chartData, setChartData] = React.useState<ChartData>({
-    chartType: ChartType.PPM,
-    glSegments: buildInitialGlSegments(),
-    ppmSegments: buildInitialPpmSegments(),
+  const [chartData, setChartData] = React.useState<ChartData>(() => {
+    const initializeFromGlSegmentString =
+      chartSegmentString && isGlSegmentString(chartSegmentString);
+
+    return {
+      chartType: initializeFromGlSegmentString ? ChartType.GL : ChartType.PPM,
+      glSegments: initializeFromGlSegmentString
+        ? fromGlSegmentString(chartSegmentString, true)
+        : buildInitialGlSegments(),
+      ppmSegments:
+        chartSegmentString && !initializeFromGlSegmentString
+          ? fromPpmSegmentString(chartSegmentString, true)
+          : buildInitialPpmSegments(),
+    };
   });
 
   // if we load up new data, update the chart

--- a/Finjector.Web/ClientApp/src/pages/Entry.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Entry.tsx
@@ -24,7 +24,7 @@ import {
   isGlSegmentString,
 } from "../util/segmentValidation";
 import NameEntry from "../components/NameEntry";
-import { mapSegmentQueryData } from "../util/segmentMapping";
+import { mapSegmentCodeToName, mapSegmentQueryData } from "../util/segmentMapping";
 import EditButtons from "../components/EditButtons";
 import { ChartDebugInfo } from "../components/ChartDebugInfo";
 import { HomeLink } from "../components/HomeLink";
@@ -50,11 +50,11 @@ const Entry = () => {
     return {
       chartType: initializeFromGlSegmentString ? ChartType.GL : ChartType.PPM,
       glSegments: initializeFromGlSegmentString
-        ? fromGlSegmentString(chartSegmentString, true)
+        ? mapSegmentCodeToName(fromGlSegmentString(chartSegmentString, true))
         : buildInitialGlSegments(),
       ppmSegments:
         chartSegmentString && !initializeFromGlSegmentString
-          ? fromPpmSegmentString(chartSegmentString, true)
+          ? mapSegmentCodeToName(fromPpmSegmentString(chartSegmentString, true))
           : buildInitialPpmSegments(),
     };
   });

--- a/Finjector.Web/ClientApp/src/util/segmentMapping.ts
+++ b/Finjector.Web/ClientApp/src/util/segmentMapping.ts
@@ -1,4 +1,5 @@
 import { ChartData, ChartType } from "../types";
+import { GlSegments, PpmSegments } from "../types";
 
 // only GL validation returns segment names, otherwise we just use segment codes
 export const mapSegmentQueryData = (
@@ -31,4 +32,15 @@ export const mapSegmentQueryData = (
       }
     });
   }
+};
+
+export const mapSegmentCodeToName = <T extends GlSegments | PpmSegments>(
+  segments: T
+): T => {
+  Object.keys(segments).forEach((segmentKey: string) => {
+    const segment = (segments as any)[segmentKey];
+    segment.name = segment.code;
+  });
+
+  return segments;
 };

--- a/Finjector.Web/ClientApp/src/util/segmentValidation.ts
+++ b/Finjector.Web/ClientApp/src/util/segmentValidation.ts
@@ -44,7 +44,19 @@ const isPpmWithoutAward = (ppm: PpmSegments): boolean => {
 };
 
 export const isGlSegmentString = (segmentString: string): boolean => {
-  return segmentString.split("-").length === 11;
+  return (
+    segmentString.match(
+      "^[0-9]{3}[0-9AB]-[0-9A-Z]{5}-[0-9A-Z]{7}-[0-9A-Z]{6}-[0-9][0-9A-Z]-[0-9A-Z]{3}-[0-9A-Z]{10}-[0-9A-Z]{6}-0000-000000-000000$"
+    ) !== null
+  );
+};
+
+export const isPpmSegmentString = (segmentString: string): boolean => {
+  return (
+    segmentString.match(
+      "^[0-9A-Z]{10}-[0-9A-Z]{6}-[0-9A-Z]{7}-[0-9A-Z]{6}(-[0-9A-Z]{7}-[0-9A-Z]{5})?$"
+    ) !== null
+  );
 };
 
 export const getSegmentValue = (segment: SegmentData): string => {


### PR DESCRIPTION
Edit page can now take in no params (create from scratch), a CoA param (create from CoA) and both `/ID/CoA`  (create from existing saved).   If CoA param is passed, it checks for valid GL structure, and if not assumes PPM, which I think is good enough since we default to PPM anyway -- if it's really a totally invalid string it basically loads up similar to from scratch anyway.

part 2 -- I rewrote the paste page to be simpler -- just a textbox to paste your string into.  the string is checked for structure completeness as GL or PPM, and if it looks good you can click next and it'll drop you into the new entry page.

closes #99