### PR TITLE
Dump cosmos db and do everything in SQL

### DIFF
--- a/Finjector.Core/Domain/User.cs
+++ b/Finjector.Core/Domain/User.cs
@@ -14,15 +14,15 @@ namespace Finjector.Core.Domain
         public int Id { get; set; }
 
         [MaxLength(10)]
-        public string Iam { get; set; }
+        public string Iam { get; set; } = string.Empty;
 
         [MaxLength(20)]
-        public string Kerberos { get; set; }
+        public string Kerberos { get; set; } = string.Empty;
 
         [Required]
         [MaxLength(300)]
         [EmailAddress]
-        public string Email { get; set; }
+        public string Email { get; set; } = string.Empty;
 
         public bool IsActive { get; set; } = true;
 
@@ -31,12 +31,12 @@ namespace Finjector.Core.Domain
         [Required]
         [MaxLength(50)]
         [Display(Name = "First Name")]
-        public string FirstName { get; set; }
+        public string FirstName { get; set; } = string.Empty;
 
         [Required]
         [MaxLength(50)]
         [Display(Name = "Last Name")]
-        public string LastName { get; set; }
+        public string LastName { get; set; } = string.Empty;
 
 
         [Display(Name = "Name")]

--- a/Finjector.Core/Services/IdentityService.cs
+++ b/Finjector.Core/Services/IdentityService.cs
@@ -12,9 +12,9 @@ namespace Finjector.Core.Services
 {
     public interface IIdentityService
     {
-        Task<User> GetByKerberos(string kerb);
+        Task<User?> GetByKerberos(string kerb);
         Task<User?> GetByIam(string iam);
-        Task<User> GetByEmail(string email);
+        Task<User?> GetByEmail(string email);
     }
 
     public class IdentityService : IIdentityService
@@ -26,7 +26,7 @@ namespace Finjector.Core.Services
             _authOptions = authOptions.Value;
         }
 
-        public async Task<User> GetByEmail(string email)
+        public async Task<User?> GetByEmail(string email)
         {
             var clientws = new IetClient(_authOptions.IamKey);
             // get IAM from email
@@ -56,7 +56,7 @@ namespace Finjector.Core.Services
         }
 
 
-        public async Task<User> GetByKerberos(string kerb)
+        public async Task<User?> GetByKerberos(string kerb)
         {
             var clientws = new IetClient(_authOptions.IamKey);
             var ucdKerbResult = await clientws.Kerberos.Search(KerberosSearchField.userId, kerb);

--- a/Finjector.Core/Services/IdentityService.cs
+++ b/Finjector.Core/Services/IdentityService.cs
@@ -13,7 +13,7 @@ namespace Finjector.Core.Services
     public interface IIdentityService
     {
         Task<User> GetByKerberos(string kerb);
-        Task<User> GetByIam(string iam);
+        Task<User?> GetByIam(string iam);
         Task<User> GetByEmail(string email);
     }
 
@@ -92,7 +92,7 @@ namespace Finjector.Core.Services
             return user;
         }
 
-        public async Task<User> GetByIam(string iam)
+        public async Task<User?> GetByIam(string iam)
         {
             var clientws = new IetClient(_authOptions.IamKey);
             var ucdKerbResult = await clientws.Kerberos.Search(KerberosSearchField.iamId, iam);

--- a/Finjector.Web/ClientApp/src/components/ChartList.tsx
+++ b/Finjector.Web/ClientApp/src/components/ChartList.tsx
@@ -23,7 +23,7 @@ const ChartList = (props: Props) => {
 
   const filteredCharts = charts.filter((chart) => {
     return (
-      chart.displayName.toLowerCase().includes(filterLowercase) ||
+      chart.name.toLowerCase().includes(filterLowercase) ||
       chart.segmentString.toLowerCase().includes(filterLowercase)
     );
   });
@@ -36,7 +36,7 @@ const ChartList = (props: Props) => {
           key={chart.id}
         >
           <div className="col-9 ms-2 me-auto">
-            <div className="fw-bold "> {chart.displayName}</div>
+            <div className="fw-bold "> {chart.name}</div>
             <span style={{ wordWrap: "break-word" }}>
               {chart.segmentString}
             </span>

--- a/Finjector.Web/ClientApp/src/components/ChartLoadingError.tsx
+++ b/Finjector.Web/ClientApp/src/components/ChartLoadingError.tsx
@@ -9,7 +9,7 @@ export const ChartLoadingError = () => {
   const removeMutation = useRemoveChart();
 
   const remove = () => {
-    removeMutation.mutate({ id: id || "" } as Chart, {
+    removeMutation.mutate({ id: id || 0 } as Chart, {
       onSuccess: () => {
         navigate("/");
       },

--- a/Finjector.Web/ClientApp/src/components/EditButtons.tsx
+++ b/Finjector.Web/ClientApp/src/components/EditButtons.tsx
@@ -36,8 +36,8 @@ const EditButtons = (props: Props) => {
     // create a new chart based on the starting point of current chart
     const chartToSave: Chart = {
       ...props.savedChart,
-      id: "",
-      displayName: `${props.savedChart.displayName} (copy)`,
+      id: 0,
+      name: `${props.savedChart.name} (copy)`,
       segmentString: toSegmentString(props.chartData),
     };
 
@@ -75,7 +75,7 @@ const EditButtons = (props: Props) => {
       <button
         type="button"
         className="btn btn-secondary flex-fill me-3"
-        disabled={saveMutation.isLoading || !props.savedChart.displayName}
+        disabled={saveMutation.isLoading || !props.savedChart.name}
         onClick={copy}
       >
         Duplicate
@@ -83,7 +83,7 @@ const EditButtons = (props: Props) => {
       <button
         className="btn btn-secondary flex-fill me-3"
         type="button"
-        disabled={saveMutation.isLoading || !props.savedChart.displayName}
+        disabled={saveMutation.isLoading || !props.savedChart.name}
         onClick={save}
       >
         Save

--- a/Finjector.Web/ClientApp/src/components/NameEntry.tsx
+++ b/Finjector.Web/ClientApp/src/components/NameEntry.tsx
@@ -17,9 +17,9 @@ const NameEntry = (props: Props) => {
             required
             type="text"
             className="form-control"
-            valid={props.chart.displayName.length > 0}
-            invalid={props.chart.displayName.length === 0}
-            value={props.chart.displayName}
+            valid={props.chart.name.length > 0}
+            invalid={props.chart.name.length === 0}
+            value={props.chart.name}
             onChange={(e) => props.updateDisplayName(e.target.value)}
           />
         </form>

--- a/Finjector.Web/ClientApp/src/components/NameEntry.tsx
+++ b/Finjector.Web/ClientApp/src/components/NameEntry.tsx
@@ -5,7 +5,7 @@ import { Chart } from "../types";
 
 interface Props {
   chart: Chart;
-  updateDisplayName: (name: string) => void;
+  updateName: (name: string) => void;
 }
 const NameEntry = (props: Props) => {
   return (
@@ -20,7 +20,7 @@ const NameEntry = (props: Props) => {
             valid={props.chart.name.length > 0}
             invalid={props.chart.name.length === 0}
             value={props.chart.name}
-            onChange={(e) => props.updateDisplayName(e.target.value)}
+            onChange={(e) => props.updateName(e.target.value)}
           />
         </form>
       </div>

--- a/Finjector.Web/ClientApp/src/components/SaveAndUseButton.tsx
+++ b/Finjector.Web/ClientApp/src/components/SaveAndUseButton.tsx
@@ -33,7 +33,7 @@ const SaveAndUseButton = (props: Props) => {
       <button
         className="btn btn-primary"
         type="button"
-        disabled={saveMutation.isLoading || !props.savedChart.displayName}
+        disabled={saveMutation.isLoading || !props.savedChart.name}
         onClick={saveAndUse}
       >
         Save and use

--- a/Finjector.Web/ClientApp/src/components/SaveAndUseButton.tsx
+++ b/Finjector.Web/ClientApp/src/components/SaveAndUseButton.tsx
@@ -18,6 +18,7 @@ const SaveAndUseButton = (props: Props) => {
   const saveAndUse = () => {
     const chartToSave: Chart = {
       ...props.savedChart,
+      chartType: props.chartData.chartType,
       segmentString: toSegmentString(props.chartData),
     };
 

--- a/Finjector.Web/ClientApp/src/pages/Entry.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Entry.tsx
@@ -35,10 +35,12 @@ const Entry = () => {
   const savedChartQuery = useGetSavedChartWithData(id || "");
 
   const [savedChart, setSavedChart] = React.useState<Chart>({
-    id: "",
+    id: 0,
     chartType: ChartType.PPM,
-    displayName: "",
+    name: "",
     segmentString: "",
+    folderId: 0,
+    updated: new Date(),
   });
 
   // in progress chart data

--- a/Finjector.Web/ClientApp/src/pages/Entry.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Entry.tsx
@@ -144,8 +144,8 @@ const Entry = () => {
         <h2>CoA Name</h2>
         <NameEntry
           chart={savedChart}
-          updateDisplayName={(n) =>
-            setSavedChart((c) => ({ ...c, displayName: n }))
+          updateName={(n) =>
+            setSavedChart((c) => ({ ...c, name: n }))
           }
         />
         <CoaDisplay chartData={chartData} />

--- a/Finjector.Web/ClientApp/src/pages/Paste.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Paste.tsx
@@ -25,10 +25,12 @@ const Paste = () => {
 
   // paste never starts with existing data, always start default
   const [savedChart, setSavedChart] = React.useState<Chart>({
-    id: "",
+    id: 0,
     chartType,
-    displayName: "",
+    name: "",
     segmentString: "",
+    folderId: 0,
+    updated: new Date(),
   });
 
   // in progress chart data

--- a/Finjector.Web/ClientApp/src/queries/storedChartQueries.ts
+++ b/Finjector.Web/ClientApp/src/queries/storedChartQueries.ts
@@ -41,7 +41,7 @@ export const useGetSavedChartWithData = (id: string) =>
 // save new chart
 export const useSaveChart = () =>
   useMutation(async (chart: Chart) => {
-    const savedChart: Chart = { ...chart, id: chart.id || uuidv4() };
+    const savedChart: Chart = { ...chart, id: chart.id || 0 };
 
     await fetch(`/api/charts/save`, {
       method: "POST",

--- a/Finjector.Web/ClientApp/src/queries/storedChartQueries.ts
+++ b/Finjector.Web/ClientApp/src/queries/storedChartQueries.ts
@@ -41,19 +41,19 @@ export const useGetSavedChartWithData = (id: string) =>
 // save new chart
 export const useSaveChart = () =>
   useMutation(async (chart: Chart) => {
-    const savedChart: Chart = { ...chart, id: chart.id || 0 };
-
-    await fetch(`/api/charts/save`, {
+    const response = await fetch(`/api/charts/save`, {
       method: "POST",
-      body: JSON.stringify(savedChart),
+      body: JSON.stringify(chart),
       headers: {
         Accept: "application/json",
         "Content-Type": "application/json",
       },
     });
 
+    const responseChart = await response.json();
+
     // return the saved chart
-    return savedChart;
+    return responseChart;
   });
 
 // delete chart

--- a/Finjector.Web/ClientApp/src/types.ts
+++ b/Finjector.Web/ClientApp/src/types.ts
@@ -1,8 +1,10 @@
 export interface Chart {
-  id: string;
+  id: number;
   segmentString: string;
-  displayName: string;
+  name: string;
   chartType: ChartType;
+  folderId?: number;
+  updated: Date;
 }
 
 export enum ChartType {

--- a/Finjector.Web/ClientApp/src/util/mockData.ts
+++ b/Finjector.Web/ClientApp/src/util/mockData.ts
@@ -5,10 +5,12 @@ const fakeCharts: Chart[] = [];
 // make 3 fake charts
 for (let i = 0; i < 3; i++) {
   fakeCharts.push({
-    id: `chart-${i}`,
-    displayName: `Chart ${i}`,
+    id: i,
+    name: `Chart ${i}`,
     segmentString: '3110-69882-ADNO001-480000-00-000-0000000000-000000-0000-000000-000000',
     chartType: ChartType.GL,
+    folderId: 0,
+    updated: new Date(),
   });
 }
 

--- a/Finjector.Web/Controllers/ChartsController.cs
+++ b/Finjector.Web/Controllers/ChartsController.cs
@@ -10,7 +10,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Finjector.Web.Controllers;
 
-
 [ApiController]
 [Route("api/[controller]")]
 [Authorize]
@@ -66,7 +65,7 @@ public class ChartsController : ControllerBase
             return Unauthorized();
         }
 
-        await _checkUser.UpdateUser(user);
+        await _checkUser.MigrateUser(user);
         
         // get any chart that belongs to the user's folders or teams.  role doesn't matter.
         var charts = await _dbContext.Coas.Where(c =>

--- a/Finjector.Web/Controllers/ChartsController.cs
+++ b/Finjector.Web/Controllers/ChartsController.cs
@@ -115,18 +115,27 @@ public class ChartsController : ControllerBase
             await _dbContext.CoaDetails.AddAsync(coaDetail);
         }
 
-        var chart = new Coa()
+        
+        // get the chart or create a new one
+        Coa chart;
+
+        if (chartViewModel.Id != 0)
         {
-            Folder = defaultFolder,
-            SegmentString = chartViewModel.SegmentString,
-            Detail = coaDetail,
-            Name = chartViewModel.Name,
-            ChartType = chartViewModel.ChartType,
-            Updated = DateTime.UtcNow
-        };
-
-        await _dbContext.Coas.AddAsync(chart);
-
+            chart = await _dbContext.Coas.SingleAsync(c => c.Id == chartViewModel.Id);
+        }
+        else
+        {
+            chart = new Coa();
+            await _dbContext.Coas.AddAsync(chart);
+        }
+        
+        chart.Folder = defaultFolder;
+        chart.SegmentString = chartViewModel.SegmentString;
+        chart.Detail = coaDetail;
+        chart.Name = chartViewModel.Name;
+        chart.ChartType = chartViewModel.ChartType;
+        chart.Updated = DateTime.UtcNow;
+        
         await _dbContext.SaveChangesAsync();
 
         return Ok(chart);

--- a/Finjector.Web/Controllers/ChartsController.cs
+++ b/Finjector.Web/Controllers/ChartsController.cs
@@ -5,6 +5,7 @@ using Finjector.Core.Data;
 using Finjector.Core.Domain;
 using Finjector.Web.Models;
 using Finjector.Core.Services;
+using Finjector.Web.Extensions;
 using Finjector.Web.Handlers;
 using Microsoft.EntityFrameworkCore;
 
@@ -105,12 +106,7 @@ public class ChartsController : ControllerBase
         
         if (coaDetail == null)
         {
-            // TODO: add detail on save
-            coaDetail = new CoaDetail()
-            {
-                Id = chartViewModel.SegmentString,
-                ChartType = chartViewModel.ChartType,
-            };
+            coaDetail = chartViewModel.SegmentString.ToCoADetail();
             
             await _dbContext.CoaDetails.AddAsync(coaDetail);
         }

--- a/Finjector.Web/Controllers/ChartsController.cs
+++ b/Finjector.Web/Controllers/ChartsController.cs
@@ -37,6 +37,8 @@ public class ChartsController : ControllerBase
         {
             return Unauthorized();
         }
+        
+        // TODO: verify that user has permission to view this chart
 
         var chart = await _dbContext.Coas.SingleOrDefaultAsync(c => c.Id == id);
 
@@ -68,8 +70,8 @@ public class ChartsController : ControllerBase
         
         // get any chart that belongs to the user's folders or teams.  role doesn't matter.
         var charts = await _dbContext.Coas.Where(c =>
-            c.Folder.FolderPermissions.Any(fp => fp.UserId == user.Id) ||
-            c.Folder.Team.TeamPermissions.Any(tp => tp.UserId == user.Id)).ToListAsync();
+            c.Folder.FolderPermissions.Any(fp => fp.User.Iam == iamId) ||
+            c.Folder.Team.TeamPermissions.Any(tp => tp.User.Iam == iamId)).ToListAsync();
         
         return Ok(charts);
     }
@@ -84,17 +86,13 @@ public class ChartsController : ControllerBase
             return Unauthorized();
         }
         
-        var user = await _identityService.GetByIam(iamId);
-        if (user == null)
-        {
-            return Unauthorized();
-        }
+        // TODO: verify that user has permission to save this chart
         
         // TODO: add to team and folder if specified
         
         // TODO: default folder bool?  or just move name into central config?
         // grab user's default folder
-        var defaultFolder = await _dbContext.Folders.Where(f => f.Team.IsPersonal && f.Team.OwnerId == user.Id && f.Name == "Default").SingleOrDefaultAsync();
+        var defaultFolder = await _dbContext.Folders.Where(f => f.Team.IsPersonal && f.Team.Owner.Iam == iamId && f.Name == "Default").SingleOrDefaultAsync();
         
         if (defaultFolder == null)
         {

--- a/Finjector.Web/Controllers/ChartsController.cs
+++ b/Finjector.Web/Controllers/ChartsController.cs
@@ -141,6 +141,8 @@ public class ChartsController : ControllerBase
         {
             return Unauthorized();
         }
+        
+        // TODO: make sure they are allowed to delete this chart
 
         // delete coa with id
         var chart = await _dbContext.Coas.SingleOrDefaultAsync(c => c.Id == id);
@@ -151,6 +153,8 @@ public class ChartsController : ControllerBase
         }
         
         _dbContext.Coas.Remove(chart);
+        
+        await _dbContext.SaveChangesAsync();
         
         return Ok();
     }

--- a/Finjector.Web/Extensions/StringExtensions.cs
+++ b/Finjector.Web/Extensions/StringExtensions.cs
@@ -1,4 +1,7 @@
-﻿namespace Finjector.Web.Extensions
+﻿using AggieEnterpriseApi.Validation;
+using Finjector.Core.Domain;
+
+namespace Finjector.Web.Extensions
 {
     public static class StringExtensions
     {
@@ -16,6 +19,50 @@
             }
 
             return value.Trim().Replace(" ", "%");
+        }
+
+        /// <summary>
+        /// Return segmented detail values from a CoA string
+        /// </summary>
+        /// <param name="value">Should be either a PPM or GL string</param>
+        /// <returns></returns>
+        public static CoaDetail ToCoADetail(this string value)
+        {
+            var chartType = FinancialChartValidation.GetFinancialChartStringType(value);
+
+            if (chartType == FinancialChartStringType.Invalid)
+            {
+                return new CoaDetail();
+            }
+            
+            var rtValue = new CoaDetail()
+            {
+                Id = value,
+                ChartType = chartType == FinancialChartStringType.Ppm ? "PPM" : "GL"
+            };
+            
+            if (chartType == FinancialChartStringType.Ppm)
+            {
+                var parts = value.Split('-');
+                rtValue.Project        = parts[0];
+                rtValue.Task           = parts[1];
+                rtValue.Department     = parts[2];
+                rtValue.NaturalAccount = parts[3];
+            }
+            if (chartType == FinancialChartStringType.Gl)
+            {
+                var parts = value.Split('-');
+                rtValue.Entity         = parts[0];
+                rtValue.Fund           = parts[1];
+                rtValue.Department     = parts[2];
+                rtValue.NaturalAccount = parts[3];
+                rtValue.Purpose        = parts[4];
+                rtValue.Program        = parts[5];
+                rtValue.Project        = parts[6];
+                rtValue.Activity       = parts[7];
+            }
+
+            return rtValue;
         }
     }
 }

--- a/Finjector.Web/Models/ChartViewModel.cs
+++ b/Finjector.Web/Models/ChartViewModel.cs
@@ -6,13 +6,14 @@ namespace Finjector.Web.Models
 {
     public class ChartViewModel
     {
-        [StringLength(36)]
-        public string Id { get; set; } = "";
+        public int Id { get; set; }
         [StringLength(128)]
         public string SegmentString { get; set; } = "";
         [StringLength(200)]
-        public string DisplayName { get; set; } = "";
+        public string Name { get; set; } = "";
         [StringLength(3)]
         public string ChartType { get; set; } = "";
+        
+        public int FolderId { get; set; }
     }
 }


### PR DESCRIPTION
Rewrote chart controller to use SQL for CRUD.  When using "AllCharts()" from the landing page, users are migrated one time only from cosmos.  After that, everything comes to and from SQL.

Leaving this as draft because it opens some questions that should be answered anyway and don't really have much to do with SQL.  Mostly that has to do with ensuring the user has permissions to modify and view their Coas.  But also around when we should make user teams as well as how and when to update CoA details.