### PR TITLE
Team and Group pages pass 1

### DIFF
--- a/Finjector.Web/ClientApp/src/App.test.tsx
+++ b/Finjector.Web/ClientApp/src/App.test.tsx
@@ -26,9 +26,7 @@ describe("App", () => {
 
     // should see landing page
     await waitFor(() => {
-      expect(
-        screen.getByText("Create new chart from scratch")
-      ).toBeInTheDocument();
+      expect(screen.getByText("New CoA from Scratch")).toBeInTheDocument();
     });
   });
 });

--- a/Finjector.Web/ClientApp/src/App.tsx
+++ b/Finjector.Web/ClientApp/src/App.tsx
@@ -9,6 +9,7 @@ import Selected from "./pages/Selected";
 import Entry from "./pages/Entry";
 import Paste from "./pages/Paste";
 import Header from "./shared/Header";
+import MyTeams from "./pages/Teams/MyTeams";
 
 function App() {
   const userInfoQuery = useUserInfoQuery();
@@ -26,6 +27,7 @@ function App() {
           <Route path="/" element={<Landing />} />
           <Route path="/about" element={<About />} />
           <Route path="/landing" element={<Landing />} />
+          <Route path="/teams" element={<MyTeams />} />
           <Route path="/entry">
             <Route path="" element={<Entry />} />
             <Route path=":chartSegmentString" element={<Entry />} />

--- a/Finjector.Web/ClientApp/src/App.tsx
+++ b/Finjector.Web/ClientApp/src/App.tsx
@@ -11,6 +11,7 @@ import Paste from "./pages/Paste";
 import Header from "./shared/Header";
 import MyTeams from "./pages/Teams/MyTeams";
 import Team from "./pages/Teams/Team";
+import Folder from "./pages/Teams/Folder";
 
 function App() {
   const userInfoQuery = useUserInfoQuery();
@@ -31,6 +32,7 @@ function App() {
           <Route path="/teams">
             <Route path="" element={<MyTeams />} />
             <Route path=":id" element={<Team />} />
+            <Route path=":id/folders/:folderId" element={<Folder />} />
           </Route>
           <Route path="/entry">
             <Route path="" element={<Entry />} />

--- a/Finjector.Web/ClientApp/src/App.tsx
+++ b/Finjector.Web/ClientApp/src/App.tsx
@@ -10,6 +10,7 @@ import Entry from "./pages/Entry";
 import Paste from "./pages/Paste";
 import Header from "./shared/Header";
 import MyTeams from "./pages/Teams/MyTeams";
+import Team from "./pages/Teams/Team";
 
 function App() {
   const userInfoQuery = useUserInfoQuery();
@@ -27,7 +28,10 @@ function App() {
           <Route path="/" element={<Landing />} />
           <Route path="/about" element={<About />} />
           <Route path="/landing" element={<Landing />} />
-          <Route path="/teams" element={<MyTeams />} />
+          <Route path="/teams">
+            <Route path="" element={<MyTeams />} />
+            <Route path=":id" element={<Team />} />
+          </Route>
           <Route path="/entry">
             <Route path="" element={<Entry />} />
             <Route path=":chartSegmentString" element={<Entry />} />

--- a/Finjector.Web/ClientApp/src/components/ChartList.tsx
+++ b/Finjector.Web/ClientApp/src/components/ChartList.tsx
@@ -32,16 +32,19 @@ const ChartList = (props: Props) => {
     <ul className="list-group">
       {filteredCharts.map((chart) => (
         <li
-          className="fin-item d-flex justify-content-between align-items-center saved-list-item"
+          className="coa-row is-ppm d-flex justify-content-between align-items-center saved-list-item"
           key={chart.id}
         >
           <div className="col-9 ms-2 me-auto">
+            <div className="coa-type">
+              <span>ppm</span>
+            </div>
             <div className="fw-bold "> {chart.name}</div>
             <span style={{ wordWrap: "break-word" }}>
               {chart.segmentString}
             </span>
           </div>
-          <div className="col-3">
+          <div className="col-3 text-end">
             <Link
               to={`/entry/${chart.id}/${chart.segmentString}`}
               className="btn btn-link"

--- a/Finjector.Web/ClientApp/src/components/ChartTypeSelector.tsx
+++ b/Finjector.Web/ClientApp/src/components/ChartTypeSelector.tsx
@@ -25,7 +25,7 @@ const ChartTypeSelector = (props: Props) => {
           onChange={() => setChartType(ChartType.GL)}
         />
         <label
-          className={`btn btn-outline me-3 ${
+          className={`btn btn-gl me-3 ${
             chartType === ChartType.GL ? activeClass : ""
           }`}
           htmlFor="option1"
@@ -43,7 +43,7 @@ const ChartTypeSelector = (props: Props) => {
           onChange={() => setChartType(ChartType.PPM)}
         />
         <label
-          className={`btn btn-outline ${
+          className={`btn btn-ppm ${
             chartType === ChartType.PPM ? activeClass : ""
           }`}
           htmlFor="option2"

--- a/Finjector.Web/ClientApp/src/components/SearchBar.tsx
+++ b/Finjector.Web/ClientApp/src/components/SearchBar.tsx
@@ -1,0 +1,17 @@
+export const SearchBar: React.FC<{
+  placeholderText: string;
+  search: string;
+  setSearch: React.Dispatch<React.SetStateAction<string>>;
+}> = ({ placeholderText, search, setSearch }) => {
+  return (
+    <div className="mb-3">
+      <input
+        type="search"
+        className="form-control"
+        placeholder={placeholderText}
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
+    </div>
+  );
+};

--- a/Finjector.Web/ClientApp/src/components/Teams/FolderList.tsx
+++ b/Finjector.Web/ClientApp/src/components/Teams/FolderList.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+import FinLoader from "../FinLoader";
+
+import {TeamResponseModel, TeamsResponseModel} from "../../types";
+import { Link } from "react-router-dom";
+
+interface Props {
+  teamModel: TeamResponseModel | undefined;
+  filter: string;
+}
+
+const FolderList = (props: Props) => {
+  const { teamModel } = props;
+
+  if (!teamModel) {
+    return <FinLoader />;
+  }
+
+  const filterLowercase = props.filter.toLowerCase();
+
+  const filteredFolderInfo = teamModel.folders.filter((f) => {
+    return f.folder.name.toLowerCase().includes(filterLowercase);
+  });
+
+  return (
+    <ul className="list-group">
+      {filteredFolderInfo.map((folderInfo) => (
+        <li
+          className="fin-item d-flex justify-content-between align-items-center saved-list-item"
+          key={folderInfo.folder.id}
+        >
+          <div className="col-9 ms-2 me-auto">
+            <div className="fw-bold "> {folderInfo.folder.name}</div>
+            <Link to={`/teams/${teamModel.team.id}/folders/${folderInfo.folder.id}`}>Go to Folder</Link>
+          </div>
+          <div className="col-3">
+            { folderInfo.chartCount } | { folderInfo.folderMemberCount }
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default FolderList;

--- a/Finjector.Web/ClientApp/src/components/Teams/FolderList.tsx
+++ b/Finjector.Web/ClientApp/src/components/Teams/FolderList.tsx
@@ -2,8 +2,11 @@ import React from "react";
 
 import FinLoader from "../FinLoader";
 
-import {TeamResponseModel, TeamsResponseModel} from "../../types";
+import { TeamResponseModel, TeamsResponseModel } from "../../types";
 import { Link } from "react-router-dom";
+
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faUsers, faBolt } from "@fortawesome/free-solid-svg-icons";
 
 interface Props {
   teamModel: TeamResponseModel | undefined;
@@ -26,16 +29,31 @@ const FolderList = (props: Props) => {
   return (
     <ul className="list-group">
       {filteredFolderInfo.map((folderInfo) => (
-        <li
-          className="fin-item d-flex justify-content-between align-items-center saved-list-item"
-          key={folderInfo.folder.id}
-        >
-          <div className="col-9 ms-2 me-auto">
-            <div className="fw-bold "> {folderInfo.folder.name}</div>
-            <Link to={`/teams/${teamModel.team.id}/folders/${folderInfo.folder.id}`}>Go to Folder</Link>
+        <li className="fin-row saved-list-item" key={folderInfo.folder.id}>
+          <div className="fin-info d-flex justify-content-between align-items-center">
+            <div className="col-9 ms-2 me-auto">
+              <div className="row-title">
+                <h3>{folderInfo.folder.name}</h3>
+              </div>
+            </div>
+            <div className="col-3 d-flex justify-content-end">
+              <div className="stat-icon">
+                <FontAwesomeIcon icon={faUsers} />
+                {folderInfo.folderMemberCount}
+              </div>
+              <div className="stat-icon">
+                <FontAwesomeIcon icon={faBolt} />
+                {folderInfo.chartCount}
+              </div>
+            </div>
           </div>
-          <div className="col-3">
-            { folderInfo.chartCount } | { folderInfo.folderMemberCount }
+          <div className="fin-actions">
+            <Link
+              className="bold-link"
+              to={`/teams/${teamModel.team.id}/folders/${folderInfo.folder.id}`}
+            >
+              Go to Folder
+            </Link>
           </div>
         </li>
       ))}

--- a/Finjector.Web/ClientApp/src/components/Teams/TeamList.tsx
+++ b/Finjector.Web/ClientApp/src/components/Teams/TeamList.tsx
@@ -5,6 +5,14 @@ import FinLoader from "../FinLoader";
 import { TeamsResponseModel } from "../../types";
 import { Link } from "react-router-dom";
 
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faFolderOpen,
+  faUsers,
+  faBolt,
+  faList,
+} from "@fortawesome/free-solid-svg-icons";
+
 interface Props {
   teamsInfo: TeamsResponseModel[] | undefined;
   filter: string;
@@ -26,20 +34,36 @@ const ChartList = (props: Props) => {
   return (
     <ul className="list-group">
       {filteredTeamsInfo.map((teamInfo) => (
-        <li
-          className="fin-item d-flex justify-content-between align-items-center saved-list-item"
-          key={teamInfo.team.id}
-        >
-          <div className="col-9 ms-2 me-auto">
-            <div className="fw-bold "> {teamInfo.team.name}</div>
-            <Link to={`/teams/${teamInfo.team.id}`}>Go to Team</Link>
-            <span style={{ wordWrap: "break-word" }}>
-              Admins: {teamInfo.admins.join(", ")}
-            </span>
+        <li className="fin-row saved-list-item" key={teamInfo.team.id}>
+          <div className="fin-info d-flex justify-content-between align-items-center">
+            <div className="col-9 ms-2 me-auto">
+              <h3 className="row-title">{teamInfo.team.name}</h3>
+              <p className="row-subtitle">
+                <span style={{ wordWrap: "break-word" }}>
+                  Admins: {teamInfo.admins.join(", ")}
+                </span>
+              </p>
+            </div>
+            <div className="col-3 d-flex justify-content-end">
+              <div className="stat-icon">
+                <FontAwesomeIcon icon={faFolderOpen} />
+                {teamInfo.folderCount}{" "}
+              </div>
+              <div className="stat-icon">
+                <FontAwesomeIcon icon={faUsers} />
+                {teamInfo.teamPermissionCount + teamInfo.folderPermissionCount}
+              </div>
+              <div className="stat-icon">
+                <FontAwesomeIcon icon={faBolt} />
+                {teamInfo.chartCount}
+              </div>
+            </div>
           </div>
-          <div className="col-3">
-            {teamInfo.chartCount} | {teamInfo.folderCount} |{" "}
-            {teamInfo.teamPermissionCount + teamInfo.folderPermissionCount}
+          <div className="fin-actions">
+            <Link className="bold-link" to={`/teams/${teamInfo.team.id}`}>
+              <FontAwesomeIcon icon={faList} />
+              Go to Team
+            </Link>
           </div>
         </li>
       ))}

--- a/Finjector.Web/ClientApp/src/components/Teams/TeamList.tsx
+++ b/Finjector.Web/ClientApp/src/components/Teams/TeamList.tsx
@@ -2,11 +2,11 @@ import React from "react";
 
 import FinLoader from "../FinLoader";
 
-import { TeamResponse } from "../../types";
+import { TeamsResponseModel } from "../../types";
 import { Link } from "react-router-dom";
 
 interface Props {
-  teamsInfo: TeamResponse[] | undefined;
+  teamsInfo: TeamsResponseModel[] | undefined;
   filter: string;
 }
 

--- a/Finjector.Web/ClientApp/src/components/Teams/TeamList.tsx
+++ b/Finjector.Web/ClientApp/src/components/Teams/TeamList.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+
+import FinLoader from "../FinLoader";
+
+import { TeamResponse } from "../../types";
+import { Link } from "react-router-dom";
+
+interface Props {
+  teamsInfo: TeamResponse[] | undefined;
+  filter: string;
+}
+
+const ChartList = (props: Props) => {
+  const { teamsInfo } = props;
+
+  if (!teamsInfo) {
+    return <FinLoader />;
+  }
+
+  const filterLowercase = props.filter.toLowerCase();
+
+  const filteredTeamsInfo = teamsInfo.filter((teamInfo) => {
+    return teamInfo.team.name.toLowerCase().includes(filterLowercase);
+  });
+
+  return (
+    <ul className="list-group">
+      {filteredTeamsInfo.map((teamInfo) => (
+        <li
+          className="fin-item d-flex justify-content-between align-items-center saved-list-item"
+          key={teamInfo.team.id}
+        >
+          <div className="col-9 ms-2 me-auto">
+            <div className="fw-bold "> {teamInfo.team.name}</div>
+            <Link to={`/teams/${teamInfo.team.id}`}>Go to Team</Link>
+            <span style={{ wordWrap: "break-word" }}>
+              Admins: {teamInfo.admins.join(", ")}
+            </span>
+          </div>
+          <div className="col-3">
+            {teamInfo.chartCount} | {teamInfo.folderCount} |{" "}
+            {teamInfo.teamPermissionCount + teamInfo.folderPermissionCount}
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default ChartList;

--- a/Finjector.Web/ClientApp/src/pages/Landing.test.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Landing.test.tsx
@@ -25,8 +25,12 @@ describe("Landing", () => {
     render(wrappedView());
 
     // should see the create new chart buttons
-    expect(screen.getByRole("link", { name: /create new chart from scratch/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /create new chart from paste/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /New CoA from Scratch/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /New CoA from Paste/i })
+    ).toBeInTheDocument();
   });
 
   it("loads saved charts", async () => {
@@ -41,7 +45,6 @@ describe("Landing", () => {
       expect(screen.getByText("Chart 1")).toBeInTheDocument();
     });
   });
-
 });
 
 const wrappedView = () => (

--- a/Finjector.Web/ClientApp/src/pages/Landing.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Landing.tsx
@@ -4,6 +4,9 @@ import { Link } from "react-router-dom";
 import ChartList from "../components/ChartList";
 import { useGetSavedCharts } from "../queries/storedChartQueries";
 
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPlus, faPaste } from "@fortawesome/free-solid-svg-icons";
+
 // Main landing screen for popup
 
 const Landing = () => {
@@ -13,24 +16,28 @@ const Landing = () => {
 
   return (
     <div>
+      <div className="page-title mb-3">
+        <h1>My Charts</h1>
+      </div>
       <div className="mb-3">
         <input
           type="search"
-          className="form-control"
+          className="form-control searchbar"
           placeholder="Search my saved charts"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
         />
       </div>
-      <hr />
       <div className="row justify-content-between">
-        <div className="d-grid gap-2">
-          <Link to="/entry" className="btn btn-new">
-            Create new chart from scratch
+        <div className="d-grid gap-2 d-md-block">
+          <Link to="/entry" className="btn btn-new me-3">
+            <FontAwesomeIcon icon={faPlus} />
+            New CoA from Scratch
           </Link>
 
           <Link to="/paste" className="btn btn-new">
-            Create new chart from paste
+            <FontAwesomeIcon icon={faPaste} />
+            New CoA from Paste
           </Link>
         </div>
       </div>

--- a/Finjector.Web/ClientApp/src/pages/Teams/Folder.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/Folder.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { SearchBar } from "../../components/SearchBar";
+import { useParams } from "react-router-dom";
+import { useGetFolder } from "../../queries/folderQueries";
+import ChartList from "../../components/ChartList";
+
+// show folder info w/ charts
+const Folder: React.FC = () => {
+  const { id, folderId } = useParams<{ id: string; folderId: string }>();
+
+  const [search, setSearch] = React.useState("");
+
+  const folderModel = useGetFolder(folderId);
+
+  return (
+    <div>
+      <SearchBar
+        placeholderText="Search Within Group"
+        search={search}
+        setSearch={setSearch}
+      />
+
+      <h3>Folder name: {folderModel.data?.folder.name}</h3>
+      <h3>Team name: {folderModel.data?.folder.teamName}</h3>
+      <ChartList charts={folderModel.data?.charts} filter={search} />
+    </div>
+  );
+};
+
+export default Folder;

--- a/Finjector.Web/ClientApp/src/pages/Teams/Folder.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/Folder.tsx
@@ -14,14 +14,20 @@ const Folder: React.FC = () => {
 
   return (
     <div>
-      <SearchBar
-        placeholderText="Search Within Group"
-        search={search}
-        setSearch={setSearch}
-      />
-
-      <h3>Folder name: {folderModel.data?.folder.name}</h3>
-      <h3>Team name: {folderModel.data?.folder.teamName}</h3>
+      <div className="page-title">
+        <h1>{folderModel.data?.folder.name}</h1>
+      </div>
+      <div className="page-info mb-3">
+        <p>Team - {folderModel.data?.folder.teamName}</p>
+        <p>Admins: x y z</p>
+      </div>
+      <div className="mb-3">
+        <SearchBar
+          placeholderText="Search Within Folder"
+          search={search}
+          setSearch={setSearch}
+        />
+      </div>
       <ChartList charts={folderModel.data?.charts} filter={search} />
     </div>
   );

--- a/Finjector.Web/ClientApp/src/pages/Teams/MyTeams.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/MyTeams.tsx
@@ -1,26 +1,33 @@
 import React from "react";
-import {SearchBar} from "../../components/SearchBar";
-import {useGetMyTeams} from "../../queries/teamQueries";
+import { SearchBar } from "../../components/SearchBar";
+import { useGetMyTeams } from "../../queries/teamQueries";
 import TeamList from "../../components/Teams/TeamList";
 
 const MyTeams: React.FC = () => {
-    const [search, setSearch] = React.useState("");
+  const [search, setSearch] = React.useState("");
 
-    const myTeams = useGetMyTeams();
+  const myTeams = useGetMyTeams();
 
-    return (
-        <div>
-            <SearchBar
-                placeholderText="Search My Teams"
-                search={search}
-                setSearch={setSearch}
-            />
-            <TeamList teamsInfo={myTeams.data} filter={search}/>
-            <button className="btn btn-outline-secondary flex-fill me-3" type="button">
-                Create New Team
-            </button>
-        </div>
-    );
+  return (
+    <div>
+      <div className="page-title mb-3">
+        <h1>My Teams</h1>
+      </div>
+      <div className="mb-3">
+        <SearchBar
+          placeholderText="Search My Teams"
+          search={search}
+          setSearch={setSearch}
+        />
+      </div>
+      <div className="mb-3">
+        <TeamList teamsInfo={myTeams.data} filter={search} />
+      </div>
+      <button className="btn btn-new me-3" type="button">
+        Create New Team
+      </button>
+    </div>
+  );
 };
 
 export default MyTeams;

--- a/Finjector.Web/ClientApp/src/pages/Teams/MyTeams.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/MyTeams.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { SearchBar } from "../../components/SearchBar";
+
+const MyTeams: React.FC = () => {
+  const [search, setSearch] = React.useState("");
+
+  // TODO: query for teams
+
+  return (
+    <div>
+      <SearchBar
+        placeholderText="Search My Teams"
+        search={search}
+        setSearch={setSearch}
+      />
+      <button className="btn btn-outline-secondary flex-fill me-3" type="button">
+        Create New Team
+      </button>
+    </div>
+  );
+};
+
+export default MyTeams;

--- a/Finjector.Web/ClientApp/src/pages/Teams/MyTeams.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/MyTeams.tsx
@@ -1,23 +1,26 @@
 import React from "react";
-import { SearchBar } from "../../components/SearchBar";
+import {SearchBar} from "../../components/SearchBar";
+import {useGetMyTeams} from "../../queries/teamQueries";
+import TeamList from "../../components/Teams/TeamList";
 
 const MyTeams: React.FC = () => {
-  const [search, setSearch] = React.useState("");
+    const [search, setSearch] = React.useState("");
 
-  // TODO: query for teams
+    const myTeams = useGetMyTeams();
 
-  return (
-    <div>
-      <SearchBar
-        placeholderText="Search My Teams"
-        search={search}
-        setSearch={setSearch}
-      />
-      <button className="btn btn-outline-secondary flex-fill me-3" type="button">
-        Create New Team
-      </button>
-    </div>
-  );
+    return (
+        <div>
+            <SearchBar
+                placeholderText="Search My Teams"
+                search={search}
+                setSearch={setSearch}
+            />
+            <TeamList teamsInfo={myTeams.data} filter={search}/>
+            <button className="btn btn-outline-secondary flex-fill me-3" type="button">
+                Create New Team
+            </button>
+        </div>
+    );
 };
 
 export default MyTeams;

--- a/Finjector.Web/ClientApp/src/pages/Teams/Team.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/Team.tsx
@@ -26,7 +26,7 @@ const Team: React.FC = () => {
         className="btn btn-outline-secondary flex-fill me-3"
         type="button"
       >
-        Create New Team
+        Create New Folder
       </button>
     </div>
   );

--- a/Finjector.Web/ClientApp/src/pages/Teams/Team.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/Team.tsx
@@ -14,18 +14,23 @@ const Team: React.FC = () => {
 
   return (
     <div>
+      <div className="page-title mb-3">
+        <h1>{teamModel.data?.team.name}</h1>
+      </div>
+      <div className="mb-3"></div>
       <SearchBar
-        placeholderText="Search My Teams"
+        placeholderText={
+          !!teamModel.data?.team.name
+            ? `Search Within ${teamModel.data?.team.name}`
+            : "Search My Teams"
+        }
         search={search}
         setSearch={setSearch}
       />
-
-      <h3>Team name: {teamModel.data?.team.name}</h3>
-      <FolderList teamModel={teamModel.data} filter={search} />
-      <button
-        className="btn btn-outline-secondary flex-fill me-3"
-        type="button"
-      >
+      <div className="mb-3">
+        <FolderList teamModel={teamModel.data} filter={search} />
+      </div>
+      <button className="btn btn-new me-3" type="button">
         Create New Folder
       </button>
     </div>

--- a/Finjector.Web/ClientApp/src/pages/Teams/Team.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/Team.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { SearchBar } from "../../components/SearchBar";
+import { useGetTeam } from "../../queries/teamQueries";
+import { useParams } from "react-router-dom";
+import FolderList from "../../components/Teams/FolderList";
+
+const Team: React.FC = () => {
+  // get id from url
+  const { id } = useParams<{ id: string }>();
+
+  const [search, setSearch] = React.useState("");
+
+  const teamModel = useGetTeam(id);
+
+  return (
+    <div>
+      <SearchBar
+        placeholderText="Search My Teams"
+        search={search}
+        setSearch={setSearch}
+      />
+
+      <h3>Team name: {teamModel.data?.team.name}</h3>
+      <FolderList teamModel={teamModel.data} filter={search} />
+      <button
+        className="btn btn-outline-secondary flex-fill me-3"
+        type="button"
+      >
+        Create New Team
+      </button>
+    </div>
+  );
+};
+
+export default Team;

--- a/Finjector.Web/ClientApp/src/queries/folderQueries.tsx
+++ b/Finjector.Web/ClientApp/src/queries/folderQueries.tsx
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { doFetch } from "../util/api";
+import { FolderResponseModel } from "../types";
+
+export const useGetFolder = (id: string | undefined) =>
+  useQuery(
+    ["folders", id],
+    async () => {
+      return await doFetch<FolderResponseModel>(fetch(`/api/folder/${id}`));
+    },
+    { enabled: id !== undefined }
+  );

--- a/Finjector.Web/ClientApp/src/queries/teamQueries.ts
+++ b/Finjector.Web/ClientApp/src/queries/teamQueries.ts
@@ -1,0 +1,8 @@
+import {useQuery} from "@tanstack/react-query";
+import {doFetch} from "../util/api";
+import {TeamResponse} from "../types";
+
+export const useGetMyTeams = () =>
+    useQuery(["teams", "me"], async () => {
+        return await doFetch<TeamResponse[]>(fetch(`/api/team`))
+    });

--- a/Finjector.Web/ClientApp/src/queries/teamQueries.ts
+++ b/Finjector.Web/ClientApp/src/queries/teamQueries.ts
@@ -1,8 +1,17 @@
-import {useQuery} from "@tanstack/react-query";
-import {doFetch} from "../util/api";
-import {TeamResponse} from "../types";
+import { useQuery } from "@tanstack/react-query";
+import { doFetch } from "../util/api";
+import {TeamResponseModel, TeamsResponseModel} from "../types";
 
 export const useGetMyTeams = () =>
-    useQuery(["teams", "me"], async () => {
-        return await doFetch<TeamResponse[]>(fetch(`/api/team`))
-    });
+  useQuery(["teams", "me"], async () => {
+    return await doFetch<TeamsResponseModel[]>(fetch(`/api/team`));
+  });
+
+export const useGetTeam = (id: string | undefined) =>
+  useQuery(
+    ["teams", id],
+    async () => {
+      return await doFetch<TeamResponseModel>(fetch(`/api/team/${id}`));
+    },
+    { enabled: id !== undefined }
+  );

--- a/Finjector.Web/ClientApp/src/sass/_components.scss
+++ b/Finjector.Web/ClientApp/src/sass/_components.scss
@@ -13,24 +13,24 @@
 }
 .btn-link {
   box-shadow: none;
-  color: $primary-color;
+  color: $primary-font;
   &:hover {
     background-color: inherit;
-    color: (lighten($primary-color, 5));
+    color: (lighten($primary-font, 5));
   }
 }
 .btn-new {
   font-size: 1rem;
-  background-color: $bg-primary;
+  background-color: #fff;
   color: $primary-color;
-  border: 1px solid $borders;
+  border: 1px solid $primary-color;
   box-shadow: none;
   padding: 8px 16px;
   text-transform: none;
   &:hover {
     background-color: transparentize($primary-color, 0.85);
-    border: 1px solid $borders;
     color: $primary-color;
+    border: 1px solid $primary-color;
   }
 }
 
@@ -44,10 +44,36 @@
     color: lighten($primary-color, 7) !important;
   }
 }
-.btn-outline-active {
-  background-color: transparentize($primary-color, 0.85) !important;
+.btn-gl {
+  background-color: #fff;
+  color: $gl;
+  border-color: $gl;
+  box-shadow: none;
+  &:hover {
+    background-color: $gl-bg !important;
+    color: $gl !important;
+    border-color: $gl !important;
+  }
 }
-
+.btn-ppm {
+  background-color: #fff;
+  color: $ppm;
+  border-color: $ppm;
+  box-shadow: none;
+  &:hover {
+    background-color: $ppm-bg !important;
+    color: $ppm !important;
+    border-color: $ppm !important;
+  }
+}
+.btn-ppm.btn-outline-active {
+  background-color: $ppm !important;
+  color: #fff !important;
+}
+.btn-gl.btn-outline-active {
+  background-color: $gl !important;
+  color: #fff !important;
+}
 .california-bg {
   background-color: transparentize($california, 0.9);
   a {
@@ -111,17 +137,19 @@ hr {
   color: $primary-font;
   box-shadow: 0 0 0 0.1rem transparentize($primary-color, 0.75);
 }
+.bold-link {
+  font-family: $sans-bold;
+  text-decoration: none;
+  svg {
+    margin-right: 8px;
+  }
+}
 .back-link {
   text-decoration: none;
   margin-bottom: 8px;
   svg {
     margin-right: 8px;
   }
-}
-.fin-item {
-  border-radius: 4px;
-  border: 1px solid $borders !important;
-  padding: 1%;
 }
 
 .btn-check:checked + .btn,
@@ -187,5 +215,22 @@ hr {
   }
   100% {
     transform: translate(69%, 18%);
+  }
+}
+.coa-type {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  font-family: $sans-bold;
+}
+.is-ppm {
+  border-left: 6px solid $ppm !important;
+  .coa-type {
+    color: $ppm;
+  }
+}
+.is-gl {
+  border-left: 6px solid $gl;
+  .coa-type {
+    color: $gl;
   }
 }

--- a/Finjector.Web/ClientApp/src/sass/_import.scss
+++ b/Finjector.Web/ClientApp/src/sass/_import.scss
@@ -18,10 +18,16 @@ $theme-colors: (
 $bg-primary: transparentize($primary-color, 0.96);
 
 $primary-bg: #fff;
-$borders: #c9c3ce;
+$borders: #e6e7e9;
 $primary-font: rgba(31, 31, 31, 0.99); //
 $secondary-font: rgba(31, 31, 31, 0.7); //
 $tertiary-font: rgba(31, 31, 31, 0.48); //
+
+$gl: #d9a611;
+$ppm: $gunrock;
+
+$gl-bg: transparentize(#d9a611, 0.96);
+$ppm-bg: transparentize($gunrock, 0.96);
 
 $danger: $merlot;
 $error-color: $danger;

--- a/Finjector.Web/ClientApp/src/sass/_layout.scss
+++ b/Finjector.Web/ClientApp/src/sass/_layout.scss
@@ -30,7 +30,7 @@ body {
   background-image: url("https://registration.ucdavis.edu/Images/Media/gunrock_banner_final.svg");
   background-repeat: no-repeat;
   background-size: cover;
-  padding: 2% 0;
+  padding: 12px 0;
   margin-bottom: 2%;
   img {
     width: 235px;

--- a/Finjector.Web/ClientApp/src/sass/_regions.scss
+++ b/Finjector.Web/ClientApp/src/sass/_regions.scss
@@ -1,7 +1,49 @@
 .saved-list-item {
   margin-top: 2%;
   border: 1px solid $borders;
+  list-style: none;
   // &:hover {
   //   background-color: $bg-primary;
   // }
+  .row-title {
+    text-transform: uppercase;
+    font-family: $sans-bold;
+    margin-bottom: 0px;
+  }
+  .row-subtitle {
+    margin-bottom: 0px;
+  }
+}
+.coa-row {
+  border-radius: 4px;
+  border: 1px solid $borders !important;
+  padding: 8px;
+}
+.fin-row {
+  border-radius: 4px;
+  border: 1px solid $borders !important;
+  .fin-info {
+    padding: 20px 8px 12px 8px;
+  }
+  .fin-actions {
+    background-color: $bg-primary;
+    border-top: 1px solid $borders;
+    padding: 10px 20px;
+  }
+}
+.stat-icon {
+  margin-right: 16px;
+  color: $secondary-font;
+  font-family: $sans-bold;
+  svg {
+    margin-right: 8px;
+  }
+}
+.page-title {
+  border-bottom: 1px solid $borders;
+}
+.page-info {
+  p {
+    margin-bottom: 0;
+  }
 }

--- a/Finjector.Web/ClientApp/src/sass/_typography.scss
+++ b/Finjector.Web/ClientApp/src/sass/_typography.scss
@@ -5,6 +5,7 @@ a.header-link {
   font-size: 1rem;
   color: rgba(255, 255, 255, 0.88);
   text-decoration: none;
+  font-family: $sans-bold;
   &:hover {
     color: #fff;
   }
@@ -17,7 +18,7 @@ h4 {
 }
 h1 {
   font-weight: 600;
-  font-size: 1.8rem;
+  font-size: 1.6rem;
   a {
     text-decoration: underline;
   }

--- a/Finjector.Web/ClientApp/src/shared/Header.tsx
+++ b/Finjector.Web/ClientApp/src/shared/Header.tsx
@@ -1,5 +1,18 @@
 import { Link } from "react-router-dom";
 
+const CenteredBullet = () => (
+  <span
+    className="header-link"
+    style={{
+      marginLeft: "0.5em",
+      marginRight: "0.5em",
+      color: "white",
+    }}
+  >
+    &bull;
+  </span>
+);
+
 const Header = () => (
   <div className="header">
     <div className="container">
@@ -10,6 +23,14 @@ const Header = () => (
           </Link>
         </div>
         <div className="col-6 text-end">
+          <Link className="header-link" to="/">
+            Charts
+          </Link>
+          <CenteredBullet />
+          <Link className="header-link" to="/teams">
+            Teams
+          </Link>
+          <CenteredBullet />
           <Link className="header-link" to="/about">
             About
           </Link>

--- a/Finjector.Web/ClientApp/src/shared/Header.tsx
+++ b/Finjector.Web/ClientApp/src/shared/Header.tsx
@@ -27,10 +27,10 @@ const Header = () => (
             Charts
           </Link>
           <CenteredBullet />
-          <Link className="header-link" to="/teams">
-            Teams
-          </Link>
-          <CenteredBullet />
+          {/*<Link className="header-link" to="/teams">*/}
+          {/*  Teams*/}
+          {/*</Link>*/}
+          {/*<CenteredBullet />*/}
           <Link className="header-link" to="/about">
             About
           </Link>

--- a/Finjector.Web/ClientApp/src/types.ts
+++ b/Finjector.Web/ClientApp/src/types.ts
@@ -12,6 +12,24 @@ export enum ChartType {
   PPM = "PPM",
 }
 
+export interface Team {
+  id: number;
+  name: string;
+}
+
+/* ----- Query specific response types ------- */
+
+export interface TeamResponse {
+  team: Team;
+  folderCount: number;
+  teamPermissionCount: number;
+  folderPermissionCount: number;
+  chartCount: number;
+  admins: string[];
+}
+
+/* ----- End Query specific response types ------- */
+
 export interface GlSegments {
   account: SegmentData;
   activity: SegmentData;

--- a/Finjector.Web/ClientApp/src/types.ts
+++ b/Finjector.Web/ClientApp/src/types.ts
@@ -17,15 +17,29 @@ export interface Team {
   name: string;
 }
 
+export interface Folder {
+  id: number;
+  name: string;
+}
+
 /* ----- Query specific response types ------- */
 
-export interface TeamResponse {
+export interface TeamsResponseModel {
   team: Team;
   folderCount: number;
   teamPermissionCount: number;
   folderPermissionCount: number;
   chartCount: number;
   admins: string[];
+}
+
+export interface TeamResponseModel {
+  team: Team;
+  folders: [{
+    folder: Folder;
+    chartCount: number;
+    folderMemberCount: number;
+  }];
 }
 
 /* ----- End Query specific response types ------- */

--- a/Finjector.Web/ClientApp/src/types.ts
+++ b/Finjector.Web/ClientApp/src/types.ts
@@ -20,6 +20,10 @@ export interface Team {
 export interface Folder {
   id: number;
   name: string;
+  teamId: number;
+  teamName: string;
+  myFolderPermissions: string[];
+  myTeamPermissions: string[];
 }
 
 /* ----- Query specific response types ------- */
@@ -35,11 +39,18 @@ export interface TeamsResponseModel {
 
 export interface TeamResponseModel {
   team: Team;
-  folders: [{
-    folder: Folder;
-    chartCount: number;
-    folderMemberCount: number;
-  }];
+  folders: [
+    {
+      folder: Folder;
+      chartCount: number;
+      folderMemberCount: number;
+    }
+  ];
+}
+
+export interface FolderResponseModel {
+  folder: Folder;
+  charts: Chart[];
 }
 
 /* ----- End Query specific response types ------- */

--- a/Finjector.Web/Controllers/FolderController.cs
+++ b/Finjector.Web/Controllers/FolderController.cs
@@ -1,0 +1,51 @@
+using Finjector.Core.Data;
+using Finjector.Core.Services;
+using Finjector.Web.Extensions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Finjector.Web.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class FolderController : ControllerBase
+{
+    private readonly AppDbContext _dbContext;
+    private readonly IUserService _userService;
+
+    public FolderController(AppDbContext dbContext, IUserService userService)
+    {
+        _dbContext = dbContext;
+        _userService = userService;
+    }
+
+    /// <summary>
+    /// Get information about a specific folder
+    /// Includes folder info, permissions for that folder, as well as some metadata about the charts
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    [HttpGet("{id}")]
+    public async Task<IActionResult> Get(int id)
+    {
+        var iamId = Request.GetCurrentUserIamId();
+
+        var folder = await _dbContext.Folders
+            .Select(f => new
+            {
+                f.Id,
+                f.Name,
+                TeamName = f.Team.Name,
+                TeamId = f.Team.Id,
+                MyFolderPermissions = f.FolderPermissions.Where(fp => fp.User.Iam == iamId).Select(fp => fp.Role.Name),
+                MyTeamPermissions = f.Team.TeamPermissions.Where(tp => tp.User.Iam == iamId).Select(tp => tp.Role.Name),
+            })
+            .SingleOrDefaultAsync(f => f.Id == id);
+
+        var charts = await _dbContext.Coas.Where(c => c.FolderId == id).ToListAsync();
+
+        return Ok(new { folder, charts });
+    }
+}

--- a/Finjector.Web/Controllers/TeamController.cs
+++ b/Finjector.Web/Controllers/TeamController.cs
@@ -83,7 +83,7 @@ public class TeamController : ControllerBase
             .Select(f => new
             {
                 Folder = f.Key,
-                CoaCount = f.SelectMany(c => c.Coas).Count(),
+                ChartCount = f.SelectMany(c => c.Coas).Count(),
                 FolderMemberCount =
                     f.SelectMany(c => c.FolderPermissions).Count(),
             })

--- a/Finjector.Web/Controllers/TeamController.cs
+++ b/Finjector.Web/Controllers/TeamController.cs
@@ -1,0 +1,68 @@
+using Finjector.Core.Data;
+using Finjector.Core.Services;
+using Finjector.Web.Extensions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Finjector.Web.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class TeamController : ControllerBase
+{
+    private readonly AppDbContext _dbContext;
+    private readonly IUserService _userService;
+
+    public TeamController(AppDbContext dbContext, IUserService userService)
+    {
+        _dbContext = dbContext;
+        _userService = userService;
+    }
+
+    /// <summary>
+    /// Return all teams belonging to the current user
+    /// </summary>
+    [HttpGet]
+    [HttpGet("mine")]
+    public async Task<IActionResult> Mine()
+    {
+        var iamId = Request.GetCurrentUserIamId();
+
+        var teamResults = await _dbContext.Coas.Where(c =>
+                c.Folder.FolderPermissions.Any(fp => fp.User.Iam == iamId) ||
+                c.Folder.Team.TeamPermissions.Any(tp => tp.User.Iam == iamId))
+            .GroupBy(c => new { c.Folder.Team.Id, c.Folder.Team.Name })
+            .Select(tg => new
+            {
+                Team = tg.Key,
+                FolderCount = tg.Select(c => c.Folder.Id).Distinct().Count(),
+                Admins = tg.SelectMany(c => c.Folder.Team.TeamPermissions.Select(p => p.User.FirstName + " " + p.User.LastName)).Distinct(),
+                TeamPermissionCount = tg.SelectMany(c => c.Folder.Team.TeamPermissions.Select(p => p.UserId)).Distinct().Count(),
+                FolderPermissionCount = tg.SelectMany(c => c.Folder.FolderPermissions.Select(p => p.UserId)).Distinct().Count(),
+                ChartCount = tg.Count()
+            })
+            .ToListAsync();
+        
+        return Ok(teamResults);
+    }
+
+    public async Task<IActionResult> Get(int id)
+    {
+        // todo -- verify that user has permission to view this team
+        
+        // todo -- return team info
+        // todo: include folders, count of charts, and permissions
+    }
+    
+    // todo -- create team
+    
+    // todo -- update team
+    
+    // todo -- delete team
+    
+    // todo -- add user to team
+    
+    // todo -- remove user from team
+}

--- a/Finjector.Web/Controllers/TeamController.cs
+++ b/Finjector.Web/Controllers/TeamController.cs
@@ -13,12 +13,10 @@ namespace Finjector.Web.Controllers;
 public class TeamController : ControllerBase
 {
     private readonly AppDbContext _dbContext;
-    private readonly IUserService _userService;
 
-    public TeamController(AppDbContext dbContext, IUserService userService)
+    public TeamController(AppDbContext dbContext)
     {
         _dbContext = dbContext;
-        _userService = userService;
     }
 
     /// <summary>
@@ -51,17 +49,23 @@ public class TeamController : ControllerBase
         return Ok(teamResults);
     }
 
+    /// <summary>
+    /// Returns the details of a specific team
+    /// Includes team info, permissions for that team, as well as some metadata about the folders
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns></returns>
     [HttpGet("{id}")]
-    public async Task<IActionResult> GetTeam(int id)
+    public async Task<IActionResult> Get(int id)
     {
         var iamId = Request.GetCurrentUserIamId();
 
-        var team = await _dbContext.Teams.Include(t => t.TeamPermissions)
+        var team = await _dbContext.Teams
             .Select(t => new
             {
                 t.Id,
                 t.Name,
-                Permissions = t.TeamPermissions.Select(p => p.Role.Name)
+                MyTeamPermissions = t.TeamPermissions.Where(tp => tp.User.Iam == iamId).Select(p => p.Role.Name)
             })
             .SingleOrDefaultAsync(t => t.Id == id);
 
@@ -87,8 +91,6 @@ public class TeamController : ControllerBase
 
         return Ok(new { team, folders });
     }
-
-    // todo -- get folders for team, including coas
 
     // todo -- create team
 

--- a/Finjector.Web/Extensions/RequestExtensions.cs
+++ b/Finjector.Web/Extensions/RequestExtensions.cs
@@ -1,0 +1,12 @@
+using System.Security.Claims;
+using Finjector.Web.Handlers;
+
+namespace Finjector.Web.Extensions;
+
+public static class RequestExtensions
+{
+    public static string GetCurrentUserIamId(this HttpRequest request)
+    {
+        return request.HttpContext.User.FindFirstValue(IamIdClaimFallbackTransformer.ClaimType);
+    }
+}

--- a/Finjector.Web/Finjector.Web.csproj
+++ b/Finjector.Web/Finjector.Web.csproj
@@ -43,10 +43,6 @@
     <ProjectReference Include="..\Finjector.Core\Finjector.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Extensions\" />
-  </ItemGroup>
-
   <Target Name="DebugEnsureNodeEnv" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Debug' And !Exists('$(SpaRoot)node_modules') ">
     <!-- Ensure Node.js is installed -->
     <Exec Command="node --version" ContinueOnError="true">


### PR DESCRIPTION
Created team list, team detail, and folder detail pages.  Includes some ugly react pages and decent API methods to feed all the necessary info.  No membership management or CRUD functionality.

Created new `Folder` and `Team` controllers to handle API.  Added some helpers to simplify getting user Iam and use that for all permissions checks.  In react, added responseModel types to `types.ts` -- perhaps we might want to separate out later.  Also created a few actual folders to organize a little better pages and components so it doesn't get to be one large pages folder.