### PR TITLE
Add user management pages

### DIFF
--- a/Finjector.Core/Services/UserService.cs
+++ b/Finjector.Core/Services/UserService.cs
@@ -184,7 +184,7 @@ public class UserService : IUserService
     {
         var user = await _dbContext.Users.SingleOrDefaultAsync(u => u.Iam == iamId);
 
-        using var transaction = await _dbContext.Database.BeginTransactionAsync();
+        await using var transaction = await _dbContext.Database.BeginTransactionAsync();
 
         try
         {
@@ -232,7 +232,6 @@ public class UserService : IUserService
                 Team = team
             });
 
-            _dbContext.Users.Add(user);
             _dbContext.Teams.Add(team);
             await _dbContext.SaveChangesAsync();
 

--- a/Finjector.Core/Services/UserService.cs
+++ b/Finjector.Core/Services/UserService.cs
@@ -27,6 +27,15 @@ public interface IUserService
     Task<bool> VerifyFolderAccess(int folderId, string iamId, string role);
 
     Task<Folder> GetPersonalFolder(string iamId);
+
+    /// <summary>
+    /// make sure the user has the ability to access a given team
+    /// </summary>
+    /// <param name="teamId"></param>
+    /// <param name="iamId"></param>
+    /// <param name="role"></param>
+    /// <returns></returns>
+    Task<bool> VerifyTeamAccess(int teamId, string iamId, string role);
 }
 
 public class UserService : IUserService
@@ -60,7 +69,7 @@ public class UserService : IUserService
         {
             return false;
         }
-        
+
         if (role == Role.Codes.View)
         {
             // if we are just talking view, then any db role will have access
@@ -78,7 +87,50 @@ public class UserService : IUserService
              c.Folder.Team.TeamPermissions.Any(tp =>
                  tp.User.Iam == iamId && (tp.Role.Name == Role.Codes.Admin || tp.Role.Name == Role.Codes.Edit))));
     }
-    
+
+    /// <summary>
+    /// make sure the user has the ability to access a given team
+    /// </summary>
+    /// <param name="teamId"></param>
+    /// <param name="iamId"></param>
+    /// <param name="role"></param>
+    /// <returns></returns>
+    public async Task<bool> VerifyTeamAccess(int teamId, string iamId, string role)
+    {
+        // make sure we have valid inputs
+        if (string.IsNullOrWhiteSpace(iamId) || string.IsNullOrWhiteSpace(role))
+        {
+            return false;
+        }
+
+        if (role == Role.Codes.View)
+        {
+            // if we are just talking view, then any db role will have access
+            return await _dbContext.Teams.AnyAsync(team =>
+                team.Id == teamId &&
+                team.TeamPermissions.Any(teamPermission => teamPermission.User.Iam == iamId));
+        }
+        else if (role == Role.Codes.Edit)
+        {
+            // if we are talking edit, then you need to be an admin or editor 
+            return await _dbContext.Teams.AnyAsync(team =>
+                team.Id == teamId &&
+                team.TeamPermissions.Any(tp =>
+                    tp.User.Iam == iamId && (tp.Role.Name == Role.Codes.Admin || tp.Role.Name == Role.Codes.Edit)));
+        }
+        else if (role == Role.Codes.Admin)
+        {
+            // for admin, you have to be an admin
+            return await _dbContext.Teams.AnyAsync(team =>
+                team.Id == teamId &&
+                team.TeamPermissions.Any(tp =>
+                    tp.User.Iam == iamId && (tp.Role.Name == Role.Codes.Admin)));
+        }
+
+        // if we get here, then we don't have a valid role
+        return false;
+    }
+
     /// <summary>
     /// make sure the user has the ability to access a given folder
     /// </summary>
@@ -93,7 +145,7 @@ public class UserService : IUserService
         {
             return false;
         }
-        
+
         if (role == Role.Codes.View)
         {
             // if we are just talking view, then any db role will have access
@@ -101,7 +153,8 @@ public class UserService : IUserService
                 f.Id == folderId &&
                 (f.FolderPermissions.Any(fp => fp.User.Iam == iamId) ||
                  f.Team.TeamPermissions.Any(tp => tp.User.Iam == iamId)));
-        } else if (role == Role.Codes.Edit)
+        }
+        else if (role == Role.Codes.Edit)
         {
             // if we are talking edit, then you need to be an admin or editor 
             return await _dbContext.Folders.AnyAsync(f =>
@@ -121,7 +174,7 @@ public class UserService : IUserService
                  f.Team.TeamPermissions.Any(tp =>
                      tp.User.Iam == iamId && (tp.Role.Name == Role.Codes.Admin))));
         }
-        
+
         // if we get here, then we don't have a valid role
         return false;
     }
@@ -130,25 +183,25 @@ public class UserService : IUserService
     public async Task<User> EnsureUserExists(string iamId)
     {
         var user = await _dbContext.Users.SingleOrDefaultAsync(u => u.Iam == iamId);
-        
+
         if (user == null)
         {
             // user not found in database, so create them via IAM
             user = await _identityService.GetByIam(iamId);
-            
+
             // if we still don't have a user, then we can't do anything
             if (user == null)
             {
                 throw new Exception("User not found in IAM with IamID " + iamId);
             }
-            
+
             // we have a user from IAM, so add them to our database
             await _dbContext.Users.AddAsync(user);
             await _dbContext.SaveChangesAsync();
         }
-        
+
         // now we have a valid user in the db
-        
+
         // if user has a personal team, then we are good
         var teams = await _dbContext.Teams.Where(a => a.Owner.Iam == user.Iam && a.IsPersonal).SingleOrDefaultAsync();
 
@@ -178,7 +231,7 @@ public class UserService : IUserService
         _dbContext.Users.Add(user);
         _dbContext.Teams.Add(team);
         await _dbContext.SaveChangesAsync();
-        
+
         return user;
     }
 }

--- a/Finjector.Web/ClientApp/src/App.tsx
+++ b/Finjector.Web/ClientApp/src/App.tsx
@@ -12,6 +12,7 @@ import Header from "./shared/Header";
 import MyTeams from "./pages/Teams/MyTeams";
 import Team from "./pages/Teams/Team";
 import Folder from "./pages/Teams/Folder";
+import UserManagement from "./pages/Teams/UserManagement";
 
 function App() {
   const userInfoQuery = useUserInfoQuery();
@@ -33,6 +34,8 @@ function App() {
             <Route path="" element={<MyTeams />} />
             <Route path=":id" element={<Team />} />
             <Route path=":id/folders/:folderId" element={<Folder />} />
+            <Route path=":id/permissions" element={<UserManagement />} />
+            <Route path=":id/folders/:folderId/permissions" element={<UserManagement />} />
           </Route>
           <Route path="/entry">
             <Route path="" element={<Entry />} />

--- a/Finjector.Web/ClientApp/src/components/Teams/AddUserPermission.tsx
+++ b/Finjector.Web/ClientApp/src/components/Teams/AddUserPermission.tsx
@@ -35,11 +35,7 @@ export const AddUserPermission = (props: Props) => {
       { role, email },
       {
         onSuccess: () => {
-          // TODO: add some nice toast here
-          setRole("");
-          setEmail("");
-          setError("");
-          props.toggle();
+          resetForm();
         },
         onError: (err: any) => {
           setError(err.message);
@@ -48,9 +44,16 @@ export const AddUserPermission = (props: Props) => {
     );
   };
 
+  const resetForm = () => {
+    setRole("");
+    setEmail("");
+    setError("");
+    props.toggle();
+  };
+
   return (
-    <Modal isOpen={props.active} toggle={props.toggle}>
-      <ModalHeader toggle={props.toggle}>Add New Role</ModalHeader>
+    <Modal isOpen={props.active} toggle={resetForm}>
+      <ModalHeader toggle={resetForm}>Add New Role</ModalHeader>
       <ModalBody>
         <form>
           <div className="mb-3">

--- a/Finjector.Web/ClientApp/src/components/Teams/AddUserPermission.tsx
+++ b/Finjector.Web/ClientApp/src/components/Teams/AddUserPermission.tsx
@@ -13,7 +13,7 @@ interface Props {
 export const AddUserPermission = (props: Props) => {
   const [role, setRole] = React.useState("");
   const [email, setEmail] = React.useState("");
-  const [error, setError] = React.useState("something");
+  const [error, setError] = React.useState("");
 
   const addUserMutation = useAddUserMutation(
     props.resourceId,
@@ -38,6 +38,7 @@ export const AddUserPermission = (props: Props) => {
           // TODO: add some nice toast here
           setRole("");
           setEmail("");
+          setError("");
           props.toggle();
         },
         onError: (err: any) => {
@@ -87,9 +88,11 @@ export const AddUserPermission = (props: Props) => {
             type="button"
             className="btn btn-primary"
             onClick={handleAssignRole}
-            disabled={!formValid}
+            disabled={!formValid || addUserMutation.isLoading}
           >
-            Assign Role to User
+            {addUserMutation.isLoading
+              ? "Assigning Role..."
+              : "Assign Role to User"}
           </button>
         </form>
       </ModalBody>

--- a/Finjector.Web/ClientApp/src/components/Teams/AddUserPermission.tsx
+++ b/Finjector.Web/ClientApp/src/components/Teams/AddUserPermission.tsx
@@ -13,11 +13,14 @@ interface Props {
 export const AddUserPermission = (props: Props) => {
   const [role, setRole] = React.useState("");
   const [email, setEmail] = React.useState("");
+  const [error, setError] = React.useState("something");
 
   const addUserMutation = useAddUserMutation(
     props.resourceId,
     props.resourceType
   );
+
+  const formValid = role !== "" && email !== "";
 
   const handleRoleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     setRole(event.target.value);
@@ -37,13 +40,16 @@ export const AddUserPermission = (props: Props) => {
           setEmail("");
           props.toggle();
         },
+        onError: (err: any) => {
+          setError(err.message);
+        },
       }
     );
   };
 
   return (
     <Modal isOpen={props.active} toggle={props.toggle}>
-      <ModalHeader toggle={props.toggle}>Add New Role (TODO)</ModalHeader>
+      <ModalHeader toggle={props.toggle}>Add New Role</ModalHeader>
       <ModalBody>
         <form>
           <div className="mb-3">
@@ -74,10 +80,14 @@ export const AddUserPermission = (props: Props) => {
               onChange={handleEmailChange}
             />
           </div>
+
+          {error && <div className="alert alert-danger">{error}</div>}
+
           <button
             type="button"
             className="btn btn-primary"
             onClick={handleAssignRole}
+            disabled={!formValid}
           >
             Assign Role to User
           </button>

--- a/Finjector.Web/ClientApp/src/components/Teams/AddUserPermission.tsx
+++ b/Finjector.Web/ClientApp/src/components/Teams/AddUserPermission.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import { Modal, ModalBody, ModalHeader } from "reactstrap";
+import { useAddUserMutation } from "../../queries/userQueries";
+import { CollectionResourceType } from "../../types";
 
 interface Props {
+  resourceId: string;
+  resourceType: CollectionResourceType;
   active: boolean;
   toggle: () => void;
 }
@@ -9,6 +13,11 @@ interface Props {
 export const AddUserPermission = (props: Props) => {
   const [role, setRole] = React.useState("");
   const [email, setEmail] = React.useState("");
+
+  const addUserMutation = useAddUserMutation(
+    props.resourceId,
+    props.resourceType
+  );
 
   const handleRoleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     setRole(event.target.value);
@@ -19,7 +28,17 @@ export const AddUserPermission = (props: Props) => {
   };
 
   const handleAssignRole = () => {
-    // TODO: Implement assign role logic
+    addUserMutation.mutate(
+      { role, email },
+      {
+        onSuccess: () => {
+          // TODO: add some nice toast here
+          setRole("");
+          setEmail("");
+          props.toggle();
+        },
+      }
+    );
   };
 
   return (

--- a/Finjector.Web/ClientApp/src/components/Teams/FolderList.tsx
+++ b/Finjector.Web/ClientApp/src/components/Teams/FolderList.tsx
@@ -54,6 +54,12 @@ const FolderList = (props: Props) => {
             >
               Go to Folder
             </Link>
+            <Link
+              className="bold-link"
+              to={`/teams/${teamModel.team.id}/folders/${folderInfo.folder.id}/permissions`}
+            >
+              Manage Users
+            </Link>
           </div>
         </li>
       ))}

--- a/Finjector.Web/ClientApp/src/components/Teams/FolderList.tsx
+++ b/Finjector.Web/ClientApp/src/components/Teams/FolderList.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import FinLoader from "../FinLoader";
 
-import { TeamResponseModel, TeamsResponseModel } from "../../types";
+import { TeamResponseModel } from "../../types";
 import { Link } from "react-router-dom";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -54,12 +54,14 @@ const FolderList = (props: Props) => {
             >
               Go to Folder
             </Link>
-            <Link
-              className="bold-link"
-              to={`/teams/${teamModel.team.id}/folders/${folderInfo.folder.id}/permissions`}
-            >
-              Manage Users
-            </Link>
+            {!props.teamModel?.team.isPersonal && (
+              <Link
+                className="bold-link"
+                to={`/teams/${teamModel.team.id}/folders/${folderInfo.folder.id}/permissions`}
+              >
+                Manage Users
+              </Link>
+            )}
           </div>
         </li>
       ))}

--- a/Finjector.Web/ClientApp/src/components/Teams/RemoveUserPermissions.tsx
+++ b/Finjector.Web/ClientApp/src/components/Teams/RemoveUserPermissions.tsx
@@ -1,0 +1,28 @@
+import { useRemoveUserMutation } from "../../queries/userQueries";
+import { CollectionResourceType } from "../../types";
+
+interface Props {
+  resourceId: string;
+  resourceType: CollectionResourceType;
+  userEmail: string;
+}
+
+export const RemoveUserPermission = (props: Props) => {
+  const removeUserMutation = useRemoveUserMutation(
+    props.resourceId,
+    props.resourceType
+  );
+
+  const removeInProgress =
+    removeUserMutation.isLoading || removeUserMutation.isSuccess;
+
+  const handleRemovePermission = () => {
+    removeUserMutation.mutate({ email: props.userEmail });
+  };
+
+  return (
+    <button onClick={handleRemovePermission} disabled={removeInProgress}>
+      {removeInProgress ? "Removing..." : "Remove"}
+    </button>
+  );
+};

--- a/Finjector.Web/ClientApp/src/components/Teams/TeamList.tsx
+++ b/Finjector.Web/ClientApp/src/components/Teams/TeamList.tsx
@@ -64,10 +64,15 @@ const ChartList = (props: Props) => {
               <FontAwesomeIcon icon={faList} />
               Go to Team
             </Link>
-            <Link className="bold-link" to={`/teams/${teamInfo.team.id}/permissions`}>
-              <FontAwesomeIcon icon={faList} />
-              Manage Users
-            </Link>
+            {!teamInfo.team.isPersonal && (
+              <Link
+                className="bold-link"
+                to={`/teams/${teamInfo.team.id}/permissions`}
+              >
+                <FontAwesomeIcon icon={faList} />
+                Manage Users
+              </Link>
+            )}
           </div>
         </li>
       ))}

--- a/Finjector.Web/ClientApp/src/components/Teams/TeamList.tsx
+++ b/Finjector.Web/ClientApp/src/components/Teams/TeamList.tsx
@@ -64,6 +64,10 @@ const ChartList = (props: Props) => {
               <FontAwesomeIcon icon={faList} />
               Go to Team
             </Link>
+            <Link className="bold-link" to={`/teams/${teamInfo.team.id}/permissions`}>
+              <FontAwesomeIcon icon={faList} />
+              Manage Users
+            </Link>
           </div>
         </li>
       ))}

--- a/Finjector.Web/ClientApp/src/pages/Teams/AddUserPermission.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/AddUserPermission.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { Modal, ModalBody, ModalHeader } from "reactstrap";
+
+interface Props {
+  active: boolean;
+  toggle: () => void;
+}
+
+export const AddUserPermission = (props: Props) => {
+  const [role, setRole] = React.useState("");
+  const [email, setEmail] = React.useState("");
+
+  const handleRoleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setRole(event.target.value);
+  };
+
+  const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setEmail(event.target.value);
+  };
+
+  const handleAssignRole = () => {
+    // TODO: Implement assign role logic
+  };
+
+  return (
+    <Modal isOpen={props.active} toggle={props.toggle}>
+      <ModalHeader toggle={props.toggle}>Add New Role (TODO)</ModalHeader>
+      <ModalBody>
+        <form>
+          <div className="mb-3">
+            <label htmlFor="role" className="form-label">
+              Role
+            </label>
+            <select
+              id="role"
+              className="form-select"
+              value={role}
+              onChange={handleRoleChange}
+            >
+              <option value="">Select Role</option>
+              <option value="view">View</option>
+              <option value="edit">Edit</option>
+              <option value="admin">Admin</option>
+            </select>
+          </div>
+          <div className="mb-3">
+            <label htmlFor="email" className="form-label">
+              Email
+            </label>
+            <input
+              type="text"
+              id="email"
+              className="form-control"
+              value={email}
+              onChange={handleEmailChange}
+            />
+          </div>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={handleAssignRole}
+          >
+            Assign Role to User
+          </button>
+        </form>
+      </ModalBody>
+    </Modal>
+  );
+};

--- a/Finjector.Web/ClientApp/src/pages/Teams/UserManagement.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/UserManagement.tsx
@@ -48,6 +48,7 @@ const UserManagement: React.FC = () => {
     <div>
       <h2>Manage Permissions</h2>
       <button onClick={toggleAddPermission}>+ Add New Role</button>
+      <button onClick={() => navigate(-1)}>Go Back</button>
       <table className="table">
         <thead>
           <tr>

--- a/Finjector.Web/ClientApp/src/pages/Teams/UserManagement.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/UserManagement.tsx
@@ -1,21 +1,22 @@
 import React from "react";
 import { useParams } from "react-router-dom";
 import { usePermissionsQuery } from "../../queries/userQueries";
-import { AddUserPermission } from "./AddUserPermission";
+import { AddUserPermission } from "../../components/Teams/AddUserPermission";
+import { CollectionResourceType } from "../../types";
 
 const UserManagement: React.FC = () => {
   // read (team) id and folderId from the url
   const { id, folderId } = useParams();
+
+  const resourceId = folderId ? folderId : id ? id : "";
+  const resourceType: CollectionResourceType = folderId ? "folder" : "team";
 
   const [addPermissionActive, setAddPermissionActive] = React.useState(false);
 
   const toggleAddPermission = () => setAddPermissionActive((p) => !p);
 
   // query for membership
-  const membershipQuery = usePermissionsQuery(
-    folderId ? folderId : id ? id : "",
-    folderId ? "folder" : "team"
-  );
+  const membershipQuery = usePermissionsQuery(resourceId, resourceType);
 
   if (membershipQuery.isLoading) {
     return <div>Loading...</div>;
@@ -49,6 +50,8 @@ const UserManagement: React.FC = () => {
         </tbody>
       </table>
       <AddUserPermission
+        resourceId={resourceId}
+        resourceType={resourceType}
         active={addPermissionActive}
         toggle={toggleAddPermission}
       />

--- a/Finjector.Web/ClientApp/src/pages/Teams/UserManagement.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/UserManagement.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link, useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { usePermissionsQuery } from "../../queries/userQueries";
 import { AddUserPermission } from "../../components/Teams/AddUserPermission";
 import { CollectionResourceType } from "../../types";

--- a/Finjector.Web/ClientApp/src/pages/Teams/UserManagement.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/UserManagement.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+import { usePermissionsQuery } from "../../queries/userQueries";
+
+const UserManagement: React.FC = () => {
+  // read (team) id and folderId from the url
+  const { id, folderId } = useParams();
+
+  // query for membership
+  const membershipQuery = usePermissionsQuery(
+    folderId ? folderId : id ? id : "",
+    folderId ? "folder" : "team"
+  );
+
+  if (membershipQuery.isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+        <h2>
+            Manage Permissions
+        </h2>
+      <button>+ Add New Role (TODO)</button>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>User Name</th>
+            <th>User Email</th>
+            <th>Role Name</th>
+          </tr>
+        </thead>
+        <tbody>
+          {membershipQuery.data &&
+            membershipQuery.data.map((member) => (
+              <tr key={member.userEmail}>
+                <td>{member.userName}</td>
+                <td>{member.userEmail}</td>
+                <td>{member.roleName}</td>
+              </tr>
+            ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default UserManagement;

--- a/Finjector.Web/ClientApp/src/pages/Teams/UserManagement.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/UserManagement.tsx
@@ -25,7 +25,7 @@ const UserManagement: React.FC = () => {
   return (
     <div>
       <h2>Manage Permissions</h2>
-      <button onClick={toggleAddPermission}>+ Add New Role (TODO)</button>
+      <button onClick={toggleAddPermission}>+ Add New Role</button>
       <table className="table">
         <thead>
           <tr>

--- a/Finjector.Web/ClientApp/src/pages/Teams/UserManagement.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/UserManagement.tsx
@@ -1,10 +1,15 @@
 import React from "react";
 import { useParams } from "react-router-dom";
 import { usePermissionsQuery } from "../../queries/userQueries";
+import { AddUserPermission } from "./AddUserPermission";
 
 const UserManagement: React.FC = () => {
   // read (team) id and folderId from the url
   const { id, folderId } = useParams();
+
+  const [addPermissionActive, setAddPermissionActive] = React.useState(false);
+
+  const toggleAddPermission = () => setAddPermissionActive((p) => !p);
 
   // query for membership
   const membershipQuery = usePermissionsQuery(
@@ -18,16 +23,15 @@ const UserManagement: React.FC = () => {
 
   return (
     <div>
-        <h2>
-            Manage Permissions
-        </h2>
-      <button>+ Add New Role (TODO)</button>
+      <h2>Manage Permissions</h2>
+      <button onClick={toggleAddPermission}>+ Add New Role (TODO)</button>
       <table className="table">
         <thead>
           <tr>
             <th>User Name</th>
             <th>User Email</th>
             <th>Role Name</th>
+            <th>Remove Role</th>
           </tr>
         </thead>
         <tbody>
@@ -37,10 +41,17 @@ const UserManagement: React.FC = () => {
                 <td>{member.userName}</td>
                 <td>{member.userEmail}</td>
                 <td>{member.roleName}</td>
+                <td>
+                  <button>Remove</button>
+                </td>
               </tr>
             ))}
         </tbody>
       </table>
+      <AddUserPermission
+        active={addPermissionActive}
+        toggle={toggleAddPermission}
+      />
     </div>
   );
 };

--- a/Finjector.Web/ClientApp/src/pages/Teams/UserManagement.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/UserManagement.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useParams } from "react-router-dom";
+import { Link, useParams, useNavigate } from "react-router-dom";
 import { usePermissionsQuery } from "../../queries/userQueries";
 import { AddUserPermission } from "../../components/Teams/AddUserPermission";
 import { CollectionResourceType } from "../../types";
@@ -8,6 +8,8 @@ import { RemoveUserPermission } from "../../components/Teams/RemoveUserPermissio
 const UserManagement: React.FC = () => {
   // read (team) id and folderId from the url
   const { id, folderId } = useParams();
+
+  const navigate = useNavigate();
 
   const resourceId = folderId ? folderId : id ? id : "";
   const resourceType: CollectionResourceType = folderId ? "folder" : "team";
@@ -21,6 +23,25 @@ const UserManagement: React.FC = () => {
 
   if (membershipQuery.isLoading) {
     return <div>Loading...</div>;
+  }
+
+  // show error message if user is unauthorized
+  if (membershipQuery.isError) {
+    var err: Error = membershipQuery.error;
+
+    var errorContent = <div>Something went wrong...</div>;
+
+    if (err.message === "401 Unauthorized") {
+      errorContent = <div>You are not authorized to view this page</div>;
+    }
+
+    return (
+      <div>
+        <h2>Manage Permissions</h2>
+        {errorContent}
+        <button onClick={() => navigate(-1)}>Go Back</button>
+      </div>
+    );
   }
 
   return (

--- a/Finjector.Web/ClientApp/src/pages/Teams/UserManagement.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/UserManagement.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import { usePermissionsQuery } from "../../queries/userQueries";
 import { AddUserPermission } from "../../components/Teams/AddUserPermission";
 import { CollectionResourceType } from "../../types";
+import { RemoveUserPermission } from "../../components/Teams/RemoveUserPermissions";
 
 const UserManagement: React.FC = () => {
   // read (team) id and folderId from the url
@@ -43,7 +44,11 @@ const UserManagement: React.FC = () => {
                 <td>{member.userEmail}</td>
                 <td>{member.roleName}</td>
                 <td>
-                  <button>Remove</button>
+                  <RemoveUserPermission
+                    resourceId={resourceId}
+                    resourceType={resourceType}
+                    userEmail={member.userEmail}
+                  />
                 </td>
               </tr>
             ))}

--- a/Finjector.Web/ClientApp/src/queries/userQueries.ts
+++ b/Finjector.Web/ClientApp/src/queries/userQueries.ts
@@ -44,7 +44,8 @@ export const useAddUserMutation = (
       });
 
       if (!res.ok) {
-        throw new Error(`${res.status} ${res.statusText}`);
+        const errorText = await res.text();
+        throw new Error(`${res.statusText}: ${errorText}`);
       }
     },
     {

--- a/Finjector.Web/ClientApp/src/queries/userQueries.ts
+++ b/Finjector.Web/ClientApp/src/queries/userQueries.ts
@@ -40,7 +40,7 @@ export const useAddUserMutation = (
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ data }),
+        body: JSON.stringify(data),
       });
 
       if (!res.ok) {

--- a/Finjector.Web/ClientApp/src/queries/userQueries.ts
+++ b/Finjector.Web/ClientApp/src/queries/userQueries.ts
@@ -20,11 +20,24 @@ export const useUserInfoQuery = () =>
 
 // fetch permission info for a given team or folder
 export const usePermissionsQuery = (id: string, type: CollectionResourceType) =>
-  useQuery(["users", "permissions", type, id], async () => {
-    return await doFetch<PermissionsResponseModel[]>(
-      fetch(`/api/user/permissions/${type}/${id}`)
-    );
-  });
+  useQuery(
+    ["users", "permissions", type, id],
+    async () => {
+      return await doFetch<PermissionsResponseModel[]>(
+        fetch(`/api/user/permissions/${type}/${id}`)
+      );
+    },
+    {
+      retry(failureCount, error: Error) {
+        if (error instanceof Error && error.message.startsWith("401")) {
+          return false;
+        }
+
+        // otherwise retry the normal amount
+        return failureCount < 3;
+      },
+    }
+  );
 
 // new mutation to add a user to a resource
 export const useAddUserMutation = (

--- a/Finjector.Web/ClientApp/src/queries/userQueries.ts
+++ b/Finjector.Web/ClientApp/src/queries/userQueries.ts
@@ -1,4 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
+import { doFetch } from "../util/api";
+import { PermissionsResponseModel } from "../types";
 
 // attempt to fetch user info -- if we get a 401, redirect to login
 export const useUserInfoQuery = () =>
@@ -14,4 +16,12 @@ export const useUserInfoQuery = () =>
     }
 
     throw new Error(`${res.status} ${res.statusText}`);
+  });
+
+// fetch permission info for a given team or folder
+export const usePermissionsQuery = (id: string, type: "team" | "folder") =>
+  useQuery(["users", "permissions", type, id], async () => {
+    return await doFetch<PermissionsResponseModel[]>(
+      fetch(`/api/user/permissions/${type}/${id}`)
+    );
   });

--- a/Finjector.Web/ClientApp/src/queries/userQueries.ts
+++ b/Finjector.Web/ClientApp/src/queries/userQueries.ts
@@ -56,3 +56,34 @@ export const useAddUserMutation = (
     }
   );
 };
+
+// new mutation to remove a user from a resource
+export const useRemoveUserMutation = (
+  id: string,
+  type: CollectionResourceType
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    async (data: { email: string }) => {
+      const res = await fetch(`/api/user/permissions/${type}/${id}`, {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(data),
+      });
+
+      if (!res.ok) {
+        const errorText = await res.text();
+        throw new Error(`${res.statusText}: ${errorText}`);
+      }
+    },
+    {
+      onSuccess: () => {
+        // invalidate the permissions query so we refetch
+        queryClient.invalidateQueries(["users", "permissions", type, id]);
+      },
+    }
+  );
+};

--- a/Finjector.Web/ClientApp/src/types.ts
+++ b/Finjector.Web/ClientApp/src/types.ts
@@ -26,6 +26,8 @@ export interface Folder {
   myTeamPermissions: string[];
 }
 
+export type CollectionResourceType = "team" | "folder";
+
 /* ----- Query specific response types ------- */
 
 export interface TeamsResponseModel {

--- a/Finjector.Web/ClientApp/src/types.ts
+++ b/Finjector.Web/ClientApp/src/types.ts
@@ -15,6 +15,7 @@ export enum ChartType {
 export interface Team {
   id: number;
   name: string;
+  isPersonal: boolean;
 }
 
 export interface Folder {

--- a/Finjector.Web/ClientApp/src/types.ts
+++ b/Finjector.Web/ClientApp/src/types.ts
@@ -53,6 +53,13 @@ export interface FolderResponseModel {
   charts: Chart[];
 }
 
+export interface PermissionsResponseModel {
+  resourceName: string;
+  roleName: string;
+  userName: string;
+  userEmail: string;
+}
+
 /* ----- End Query specific response types ------- */
 
 export interface GlSegments {

--- a/Finjector.Web/Controllers/FolderController.cs
+++ b/Finjector.Web/Controllers/FolderController.cs
@@ -39,6 +39,7 @@ public class FolderController : ControllerBase
                 f.Name,
                 TeamName = f.Team.Name,
                 TeamId = f.Team.Id,
+                TeamIsPersonal = f.Team.IsPersonal,
                 MyFolderPermissions = f.FolderPermissions.Where(fp => fp.User.Iam == iamId).Select(fp => fp.Role.Name),
                 MyTeamPermissions = f.Team.TeamPermissions.Where(tp => tp.User.Iam == iamId).Select(tp => tp.Role.Name),
             })

--- a/Finjector.Web/Controllers/TeamController.cs
+++ b/Finjector.Web/Controllers/TeamController.cs
@@ -31,7 +31,7 @@ public class TeamController : ControllerBase
         var teamResults = await _dbContext.Coas.Where(c =>
                 c.Folder.FolderPermissions.Any(fp => fp.User.Iam == iamId) ||
                 c.Folder.Team.TeamPermissions.Any(tp => tp.User.Iam == iamId))
-            .GroupBy(c => new { c.Folder.Team.Id, c.Folder.Team.Name })
+            .GroupBy(c => new { c.Folder.Team.Id, c.Folder.Team.Name, c.Folder.Team.IsPersonal })
             .Select(tg => new
             {
                 Team = tg.Key,
@@ -65,6 +65,7 @@ public class TeamController : ControllerBase
             {
                 t.Id,
                 t.Name,
+                t.IsPersonal,
                 MyTeamPermissions = t.TeamPermissions.Where(tp => tp.User.Iam == iamId).Select(p => p.Role.Name)
             })
             .SingleOrDefaultAsync(t => t.Id == id);

--- a/Finjector.Web/Controllers/UserController.cs
+++ b/Finjector.Web/Controllers/UserController.cs
@@ -1,25 +1,35 @@
+using Finjector.Core.Data;
+using Finjector.Core.Domain;
+using Finjector.Core.Services;
+using Finjector.Web.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace Finjector.Web.Controllers;
-
 
 [ApiController]
 [Route("api/[controller]")]
 [Authorize]
 public class UserController : ControllerBase
 {
-    private readonly IHttpContextAccessor httpContextAccessor;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly AppDbContext _dbContext;
+    private readonly IUserService _userService;
 
-    public UserController(IHttpContextAccessor _httpContextAccessor)
+    private const string TeamResourceType = "team";
+
+    public UserController(IHttpContextAccessor httpContextAccessor, AppDbContext dbContext, IUserService userService)
     {
-        this.httpContextAccessor = _httpContextAccessor;
+        _httpContextAccessor = httpContextAccessor;
+        _dbContext = dbContext;
+        _userService = userService;
     }
 
     [HttpGet("info")]
     public IActionResult Info()
     {
-        var claims = this.httpContextAccessor.HttpContext?.User.Claims;
+        var claims = _httpContextAccessor.HttpContext?.User.Claims;
 
         if (claims == null)
         {
@@ -28,4 +38,67 @@ public class UserController : ControllerBase
 
         return Ok(claims.ToDictionary(c => c.Type, c => c.Value));
     }
+
+    /// <summary>
+    /// get the permissions for a given resource.
+    /// Note: folder permissions are just for that folder and do not include inherited permissions from the team
+    /// </summary>
+    /// <param name="type">string value `team` or `folder`. If not "team" defaults to folder.</param>
+    /// <param name="id">ID of the team of folder</param>
+    /// <returns></returns>
+    [HttpGet("permissions/{type}/{id}")]
+    public async Task<IActionResult> Permissions(string type, int id)
+    {
+        var iamId = _httpContextAccessor.HttpContext?.Request.GetCurrentUserIamId();
+
+        if (string.IsNullOrWhiteSpace(iamId))
+        {
+            return Unauthorized();
+        }
+
+        var hasEditPermission = string.Equals(TeamResourceType, type, StringComparison.OrdinalIgnoreCase)
+            ? await _userService.VerifyFolderAccess(id, iamId, Role.Codes.Edit)
+            : await _userService.VerifyChartAccess(id, iamId, Role.Codes.Edit);
+
+        if (type == TeamResourceType)
+        {
+            var permissions = await _dbContext.TeamPermissions
+                .Where(tp => tp.TeamId == id)
+                .Select(tp => new PermissionsModel
+                {
+                    RoleName = tp.Role.Name,
+                    ResourceName = tp.Team.Name,
+                    UserName = tp.User.Name,
+                    UserEmail = tp.User.Email
+                })
+                .AsNoTracking()
+                .ToArrayAsync();
+
+            return Ok(permissions);
+        }
+        else
+        {
+            var permissions = await _dbContext.FolderPermissions
+                .Where(fp => fp.FolderId == id)
+                .Select(fp => new PermissionsModel
+                {
+                    RoleName = fp.Role.Name,
+                    ResourceName = fp.Folder.Name,
+                    UserName = fp.User.Name,
+                    UserEmail = fp.User.Email
+                })
+                .AsNoTracking()
+                .ToArrayAsync();
+
+            return Ok(permissions);
+        }
+    }
+}
+
+public class PermissionsModel
+{
+    public string? RoleName { get; set; }
+    public string? ResourceName { get; set; }
+    public string? UserName { get; set; }
+    public string? UserEmail { get; set; }
 }

--- a/Finjector.Web/Controllers/UserController.cs
+++ b/Finjector.Web/Controllers/UserController.cs
@@ -266,16 +266,16 @@ public class UserController : ControllerBase
     /// <summary>
     /// only admins can manage permissions
     /// </summary>
-    /// <param name="type"></param>
-    /// <param name="id"></param>
-    /// <param name="iamId"></param>
+    /// <param name="type">team of folder</param>
+    /// <param name="id">id of resource</param>
+    /// <param name="iamId">iam of user</param>
     /// <returns></returns>
     private async Task<bool> CanManagePermissions(string type, int id, string iamId)
     {
         // only admin permissions can view permissions
         var hasAdminPermissions = string.Equals(TeamResourceType, type, StringComparison.OrdinalIgnoreCase)
-            ? await _userService.VerifyFolderAccess(id, iamId, Role.Codes.Admin)
-            : await _userService.VerifyChartAccess(id, iamId, Role.Codes.Admin);
+            ? await _userService.VerifyTeamAccess(id, iamId, Role.Codes.Admin)
+            : await _userService.VerifyFolderAccess(id, iamId, Role.Codes.Admin);
         return hasAdminPermissions;
     }
 }


### PR DESCRIPTION
Adds user management (add, remove, view) for folders and teams.  Decided to implement as a single unified userManagement component since they are basically the same thing.  Works for backend and front-end.

A few issues remaining to consider:

1. Currently it treats personal team / default folder just like any other.  Should we?
2. Shows Manage Users on every team/folder even if you can't access it.  Clicking just tells you unauthorized. This is because we don't keep track of the user and so don't really know if they should see it or not.