### PR TITLE
New tiered charts list and more teams functionality

### DIFF
--- a/Finjector.Core/Services/UserService.cs
+++ b/Finjector.Core/Services/UserService.cs
@@ -36,6 +36,15 @@ public interface IUserService
     /// <param name="role"></param>
     /// <returns></returns>
     Task<bool> VerifyTeamAccess(int teamId, string iamId, string role);
+
+    /// <summary>
+    /// make sure the user has the ability to access any folder within a given team, or the team itself
+    /// </summary>
+    /// <param name="teamId"></param>
+    /// <param name="iamId"></param>
+    /// <param name="role"></param>
+    /// <returns></returns>
+    Task<bool> VerifyFolderWithinTeamAccess(int teamId, string iamId, string role);
 }
 
 public class UserService : IUserService
@@ -132,6 +141,64 @@ public class UserService : IUserService
     }
 
     /// <summary>
+    /// make sure the user has the ability to access any folder within a given team, or the team itself
+    /// </summary>
+    /// <param name="teamId"></param>
+    /// <param name="iamId"></param>
+    /// <param name="role"></param>
+    /// <returns></returns>
+    public async Task<bool> VerifyFolderWithinTeamAccess(int teamId, string iamId, string role)
+    {
+        // make sure we have valid inputs
+        if (string.IsNullOrWhiteSpace(iamId) || string.IsNullOrWhiteSpace(role))
+        {
+            return false;
+        }
+
+        if (role == Role.Codes.View)
+        {
+            // if we are just talking view, then any db role will have access
+            return await _dbContext.Teams.AnyAsync(team =>
+                team.Id == teamId &&
+                (
+                    team.Folders.Any(f => f.FolderPermissions.Any(fp => fp.User.Iam == iamId)) ||
+                    team.TeamPermissions.Any(teamPermission => teamPermission.User.Iam == iamId)
+                )
+            );
+        }
+        else if (role == Role.Codes.Edit)
+        {
+            // if we are talking edit, then you need to be an admin or editor 
+            return await _dbContext.Teams.AnyAsync(team =>
+                team.Id == teamId &&
+                (
+                    team.Folders.Any(f => f.FolderPermissions.Any(fp =>
+                        fp.User.Iam == iamId &&
+                        (fp.Role.Name == Role.Codes.Admin || fp.Role.Name == Role.Codes.Edit))) ||
+                    team.TeamPermissions.Any(tp =>
+                        tp.User.Iam == iamId && (tp.Role.Name == Role.Codes.Admin || tp.Role.Name == Role.Codes.Edit))
+                )
+            );
+        }
+        else if (role == Role.Codes.Admin)
+        {
+            // for admin, you have to be an admin
+            return await _dbContext.Teams.AnyAsync(team =>
+                team.Id == teamId &&
+                (
+                    team.Folders.Any(f => f.FolderPermissions.Any(fp =>
+                        fp.User.Iam == iamId && (fp.Role.Name == Role.Codes.Admin))) ||
+                    team.TeamPermissions.Any(tp =>
+                        tp.User.Iam == iamId && (tp.Role.Name == Role.Codes.Admin))
+                )
+            );
+        }
+
+        // if we get here, then we don't have a valid role
+        return false;
+    }
+
+    /// <summary>
     /// make sure the user has the ability to access a given folder
     /// </summary>
     /// <param name="folderId"></param>
@@ -207,7 +274,8 @@ public class UserService : IUserService
             // now we have a valid user in the db
 
             // if user has a personal team, then we are good
-            var teams = await _dbContext.Teams.Where(a => a.Owner.Iam == user.Iam && a.IsPersonal).SingleOrDefaultAsync();
+            var teams = await _dbContext.Teams.Where(a => a.Owner.Iam == user.Iam && a.IsPersonal)
+                .SingleOrDefaultAsync();
 
             if (teams != null)
             {

--- a/Finjector.Web/ClientApp/src/App.tsx
+++ b/Finjector.Web/ClientApp/src/App.tsx
@@ -16,6 +16,7 @@ import Folder from "./pages/Teams/Folder";
 import UserManagement from "./pages/Teams/UserManagement";
 import CreateTeam from "./pages/Teams/CreateTeam";
 import CreateFolder from "./pages/Teams/CreateFolder";
+import AdminList from "./pages/Teams/AdminList";
 
 function App() {
   const userInfoQuery = useUserInfoQuery();
@@ -40,9 +41,15 @@ function App() {
             <Route path=":id/create" element={<CreateFolder />} />
             <Route path=":id/folders/:folderId" element={<Folder />} />
             <Route path=":id/permissions" element={<UserManagement />} />
+
             <Route
               path=":id/folders/:folderId/permissions"
               element={<UserManagement />}
+            />
+            <Route path=":id/admins" element={<AdminList />} />
+            <Route
+              path=":id/folders/:folderId/admins"
+              element={<AdminList />}
             />
           </Route>
           <Route path="/entry">

--- a/Finjector.Web/ClientApp/src/components/Shared/ChartList.tsx
+++ b/Finjector.Web/ClientApp/src/components/Shared/ChartList.tsx
@@ -1,73 +1,110 @@
 import { Link } from "react-router-dom";
 import FinLoader from "./FinLoader";
 
-import { Coa, ChartType } from "../../types";
+import { ChartType, TeamGroupedCoas } from "../../types";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faPencil,
-  faBolt,
-  faScroll,
-} from "@fortawesome/free-solid-svg-icons";
+import { faBolt, faScroll } from "@fortawesome/free-solid-svg-icons";
+import { useMemo } from "react";
 
 interface Props {
-  charts: Coa[] | undefined;
+  teamGroups: TeamGroupedCoas[] | undefined;
   filter: string;
 }
 
 const ChartList = (props: Props) => {
-  const { charts } = props;
+  const { teamGroups } = props;
 
-  if (!charts) {
+  const query = props.filter.toLowerCase();
+
+  const filteredTeamGroups = useMemo(() => {
+    if (!teamGroups) return [];
+
+    if (!query) return teamGroups;
+
+    const teamGroupsClone: TeamGroupedCoas[] = JSON.parse(JSON.stringify(teamGroups));
+
+    // filter out charts that don't match the search filter
+    return teamGroupsClone.filter((teamGroup) => {
+      // Check if team name matches the query
+      if (teamGroup.team.name.toLowerCase().includes(query)) return true;
+
+      // Filter the folders within the team
+      teamGroup.folders = teamGroup.folders.filter((folder) => {
+        // Check if folder name matches the query
+        if (folder.name.toLowerCase().includes(query)) return true;
+
+        // Filter the charts within the folder
+        folder.coas = folder.coas.filter((coa) => {
+          // Check if chart name or segmentString matches the query
+          return (
+            coa.name.toLowerCase().includes(query) ||
+            coa.segmentString.toLowerCase().includes(query)
+          );
+        });
+
+        // Keep the folder if it still has charts after filtering
+        return folder.coas.length > 0;
+      });
+
+      // Keep the team if it still has folders after filtering
+      return teamGroup.folders.length > 0;
+    });
+  }, [teamGroups, query]);
+
+  if (!teamGroups) {
     return <FinLoader />;
   }
 
-  const filterLowercase = props.filter.toLowerCase();
-
-  const filteredCharts = charts.filter((chart) => {
-    return (
-      chart.name.toLowerCase().includes(filterLowercase) ||
-      chart.segmentString.toLowerCase().includes(filterLowercase)
-    );
-  });
-
   return (
-    <ul className="list-group">
-      {filteredCharts.map((chart) => (
-        <li
-          className={`coa-row ${
-            chart.chartType === ChartType.PPM ? "is-ppm" : "is-gl"
-          } d-flex justify-content-between align-items-center saved-list-item`}
-          key={chart.id}
-        >
-          <div className="col-9 ms-2 me-auto">
-            <div className="coa-type">
-              <span>{chart.chartType}</span>
+    <div>
+      {filteredTeamGroups.map((teamGroup) => (
+        <div key={teamGroup.team.id}>
+          <h2>{teamGroup.team.name}</h2>
+          {teamGroup.folders.map((folder) => (
+            <div key={folder.id}>
+              <h3>{folder.name}</h3>
+              <ul className="list-group">
+                {folder.coas.map((chart) => (
+                  <li
+                    className={`coa-row ${
+                      chart.chartType === ChartType.PPM ? "is-ppm" : "is-gl"
+                    } d-flex justify-content-between align-items-center saved-list-item`}
+                    key={chart.id}
+                  >
+                    <div className="col-9 ms-2 me-auto">
+                      <div className="coa-type">
+                        <span>{chart.chartType}</span>
+                      </div>
+                      <div className="fw-bold "> {chart.name}</div>
+                      <span style={{ wordWrap: "break-word" }}>
+                        {chart.segmentString}
+                      </span>
+                    </div>
+                    <div className="col-3 text-end">
+                      <Link
+                        to={`/details/${chart.id}/${chart.segmentString}`}
+                        className="btn btn-link"
+                      >
+                        <FontAwesomeIcon icon={faScroll} />
+                        Details
+                      </Link>
+                      <Link
+                        to={`/selected/${chart.id}/${chart.segmentString}`}
+                        className="btn btn-link"
+                      >
+                        <FontAwesomeIcon icon={faBolt} />
+                        Use
+                      </Link>
+                    </div>
+                  </li>
+                ))}
+              </ul>
             </div>
-            <div className="fw-bold "> {chart.name}</div>
-            <span style={{ wordWrap: "break-word" }}>
-              {chart.segmentString}
-            </span>
-          </div>
-          <div className="col-3 text-end">
-            <Link
-              to={`/details/${chart.id}/${chart.segmentString}`}
-              className="btn btn-link"
-            >
-              <FontAwesomeIcon icon={faScroll} />
-              Details
-            </Link>
-            <Link
-              to={`/selected/${chart.id}/${chart.segmentString}`}
-              className="btn btn-link"
-            >
-              <FontAwesomeIcon icon={faBolt} />
-              Use
-            </Link>
-          </div>
-        </li>
+          ))}
+        </div>
       ))}
-    </ul>
+    </div>
   );
 };
 

--- a/Finjector.Web/ClientApp/src/components/Shared/ChartListSimple.tsx
+++ b/Finjector.Web/ClientApp/src/components/Shared/ChartListSimple.tsx
@@ -1,0 +1,73 @@
+import { Link } from "react-router-dom";
+import FinLoader from "./FinLoader";
+
+import { Coa, ChartType } from "../../types";
+
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faBolt,
+  faScroll,
+} from "@fortawesome/free-solid-svg-icons";
+
+interface Props {
+  charts: Coa[] | undefined;
+  filter: string;
+}
+
+const ChartListSimple = (props: Props) => {
+  const { charts } = props;
+
+  if (!charts) {
+    return <FinLoader />;
+  }
+
+  const filterLowercase = props.filter.toLowerCase();
+
+  const filteredCharts = charts.filter((chart) => {
+    return (
+      chart.name.toLowerCase().includes(filterLowercase) ||
+      chart.segmentString.toLowerCase().includes(filterLowercase)
+    );
+  });
+
+  return (
+    <ul className="list-group">
+      {filteredCharts.map((chart) => (
+        <li
+          className={`coa-row ${
+            chart.chartType === ChartType.PPM ? "is-ppm" : "is-gl"
+          } d-flex justify-content-between align-items-center saved-list-item`}
+          key={chart.id}
+        >
+          <div className="col-9 ms-2 me-auto">
+            <div className="coa-type">
+              <span>{chart.chartType}</span>
+            </div>
+            <div className="fw-bold "> {chart.name}</div>
+            <span style={{ wordWrap: "break-word" }}>
+              {chart.segmentString}
+            </span>
+          </div>
+          <div className="col-3 text-end">
+            <Link
+              to={`/details/${chart.id}/${chart.segmentString}`}
+              className="btn btn-link"
+            >
+              <FontAwesomeIcon icon={faScroll} />
+              Details
+            </Link>
+            <Link
+              to={`/selected/${chart.id}/${chart.segmentString}`}
+              className="btn btn-link"
+            >
+              <FontAwesomeIcon icon={faBolt} />
+              Use
+            </Link>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default ChartListSimple;

--- a/Finjector.Web/ClientApp/src/pages/Landing.test.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Landing.test.tsx
@@ -1,18 +1,25 @@
 import React from "react";
 
 import { cleanupApiMocks, mockApi } from "../util/test";
-import { fakeCharts } from "../util/mockData";
+import { fakeFolders, fakeTeams } from "../util/mockData";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import Landing from "./Landing";
 import { render, screen, waitFor } from "@testing-library/react";
 import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
+import { TeamGroupedCoas } from "../types";
 
 afterAll(() => {
   cleanupApiMocks();
 });
 
 const mockSavedChartsCall = () => {
-  mockApi().get("/api/charts/all").reply(200, fakeCharts);
+  const fakeTeamGroups: TeamGroupedCoas[] = [
+    {
+      team: fakeTeams[0],
+      folders: [fakeFolders[0]],
+    },
+  ];
+  mockApi().get("/api/charts/all").reply(200, fakeTeamGroups);
 };
 
 // test main landing page

--- a/Finjector.Web/ClientApp/src/pages/Landing.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Landing.tsx
@@ -42,7 +42,7 @@ const Landing = () => {
         </div>
       </div>
 
-      <ChartList charts={savedCharts.data} filter={search} />
+      <ChartList teamGroups={savedCharts.data} filter={search} />
     </div>
   );
 };

--- a/Finjector.Web/ClientApp/src/pages/Teams/AdminList.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/AdminList.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+import { BackLinkBar } from "../../components/Shared/BackLinkBar";
+import { useAdminsQuery } from "../../queries/userQueries";
+import { CollectionResourceType } from "../../types";
+
+const AdminList: React.FC = () => {
+  const { id, folderId } = useParams<{ id: string; folderId: string }>();
+
+  const resourceId = folderId ? folderId : id ? id : "";
+  const resourceType: CollectionResourceType = folderId ? "folder" : "team";
+
+  // query for membership
+  const membershipQuery = useAdminsQuery(resourceId, resourceType);
+
+  if (membershipQuery.isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  // show error message if user is unauthorized
+  if (membershipQuery.isError) {
+    var err: Error = membershipQuery.error;
+
+    var errorContent = <div>Something went wrong...</div>;
+
+    if (err.message === "401 Unauthorized") {
+      errorContent = <div>You are not authorized to view this page</div>;
+    }
+
+    return (
+      <div>
+        <h2>View Permissions</h2>
+        {errorContent}
+        <BackLinkBar />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <BackLinkBar />
+      <h2>View Admins</h2>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>User Name</th>
+            <th>User Email</th>
+            <th>Level</th>
+            <th>Role Name</th>
+          </tr>
+        </thead>
+        <tbody>
+          {membershipQuery.data &&
+            membershipQuery.data
+              .filter((m) => m.roleName === "Admin")
+              .map((member) => (
+                <tr key={member.userEmail}>
+                  <td>{member.userName}</td>
+                  <td>{member.userEmail}</td>
+                  <td>{member.level}</td>
+                  <td>{member.roleName}</td>
+                </tr>
+              ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default AdminList;

--- a/Finjector.Web/ClientApp/src/pages/Teams/Folder.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/Folder.tsx
@@ -5,6 +5,7 @@ import { useGetFolder } from "../../queries/folderQueries";
 import ChartList from "../../components/Shared/ChartList";
 import { BackLinkBar } from "../../components/Shared/BackLinkBar";
 import FinLoader from "../../components/Shared/FinLoader";
+import { isPersonalOrDefault } from "../../util/teamDefinitions";
 
 // show folder info w/ charts
 const Folder: React.FC = () => {
@@ -31,6 +32,8 @@ const Folder: React.FC = () => {
     return <FinLoader />;
   }
 
+  const limitedFolder = isPersonalOrDefault(folderModel.data?.folder.name);
+
   return (
     <div>
       <BackLinkBar />
@@ -54,7 +57,7 @@ const Folder: React.FC = () => {
         />
       </div>
       {/* Admins can manage permissions */}
-      {combinedPermissions.some((p) => p === "Admin") && (
+      {!limitedFolder && combinedPermissions.some((p) => p === "Admin") && (
         <>
           <Link
             to={`/teams/${id}/folders/${folderId}/permissions`}

--- a/Finjector.Web/ClientApp/src/pages/Teams/Folder.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/Folder.tsx
@@ -2,10 +2,10 @@ import React, { useMemo } from "react";
 import { SearchBar } from "../../components/Shared/SearchBar";
 import { Link, useParams } from "react-router-dom";
 import { useGetFolder } from "../../queries/folderQueries";
-import ChartList from "../../components/Shared/ChartList";
 import { BackLinkBar } from "../../components/Shared/BackLinkBar";
 import FinLoader from "../../components/Shared/FinLoader";
 import { isPersonalOrDefault } from "../../util/teamDefinitions";
+import ChartListSimple from "../../components/Shared/ChartListSimple";
 
 // show folder info w/ charts
 const Folder: React.FC = () => {
@@ -83,7 +83,7 @@ const Folder: React.FC = () => {
         </Link>
       )}
 
-      <ChartList charts={folderModel.data?.charts} filter={search} />
+      <ChartListSimple charts={folderModel.data?.charts} filter={search} />
     </div>
   );
 };

--- a/Finjector.Web/ClientApp/src/pages/Teams/Folder.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/Folder.tsx
@@ -39,7 +39,12 @@ const Folder: React.FC = () => {
       </div>
       <div className="page-info mb-3">
         <p>Team - {folderModel.data?.folder.teamName}</p>
-        <p>Admins: x y z</p>
+        <Link
+          to={`/teams/${id}/folders/${folderId}/admins`}
+          className="btn btn-link"
+        >
+          View Folder Admins
+        </Link>
       </div>
       <div className="mb-3">
         <SearchBar
@@ -57,7 +62,10 @@ const Folder: React.FC = () => {
           >
             Manage Permissions
           </Link>
-          <Link to={`/teams/${id}/folders/${folderId}/edit`} className="btn btn-new me-3">
+          <Link
+            to={`/teams/${id}/folders/${folderId}/edit`}
+            className="btn btn-new me-3"
+          >
             Edit Folder (TODO)
           </Link>
         </>

--- a/Finjector.Web/ClientApp/src/pages/Teams/Folder.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/Folder.tsx
@@ -50,12 +50,17 @@ const Folder: React.FC = () => {
       </div>
       {/* Admins can manage permissions */}
       {combinedPermissions.some((p) => p === "Admin") && (
-        <Link
-          to={`/teams/${id}/folders/${folderId}/permissions`}
-          className="btn btn-new me-3"
-        >
-          Manage Permissions
-        </Link>
+        <>
+          <Link
+            to={`/teams/${id}/folders/${folderId}/permissions`}
+            className="btn btn-new me-3"
+          >
+            Manage Permissions
+          </Link>
+          <Link to={`/teams/${id}/folders/${folderId}/edit`} className="btn btn-new me-3">
+            Edit Folder (TODO)
+          </Link>
+        </>
       )}
       {/* Editors & above can create new chart strings */}
       {combinedPermissions.some((p) => p === "Admin" || p === "Edit") && (

--- a/Finjector.Web/ClientApp/src/pages/Teams/Team.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/Team.tsx
@@ -20,6 +20,10 @@ const Team: React.FC = () => {
     return <FinLoader />;
   }
 
+  const isTeamAdmin = teamModel.data?.team.myTeamPermissions.some(
+    (p) => p === "Admin"
+  );
+
   return (
     <div>
       <BackLinkBar />
@@ -37,15 +41,20 @@ const Team: React.FC = () => {
         setSearch={setSearch}
       />
       <div>
-        <Link to={`/teams/${id}/create`} className="btn btn-new me-3">
-          Create New Folder
-        </Link>
-        <Link to={`/teams/${id}/edit`} className="btn btn-new me-3">
-          Edit Team (TODO)
-        </Link>
-        <Link to={`/teams/${id}/permissions`} className="btn btn-new me-3">
-          Manage Team Users
-        </Link>
+        {isTeamAdmin && (
+          <>
+            <Link to={`/teams/${id}/create`} className="btn btn-new me-3">
+              Create New Folder
+            </Link>
+            <Link to={`/teams/${id}/edit`} className="btn btn-new me-3">
+              Edit Team (TODO)
+            </Link>
+            <Link to={`/teams/${id}/permissions`} className="btn btn-new me-3">
+              Manage Team Users
+            </Link>
+          </>
+        )}
+
         {teamModel.data?.team.myTeamPermissions.some((p) => p === "Admin") && (
           <DeleteTeam teamId={id} />
         )}

--- a/Finjector.Web/ClientApp/src/pages/Teams/Team.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/Team.tsx
@@ -20,6 +20,10 @@ const Team: React.FC = () => {
     return <FinLoader />;
   }
 
+  if (teamModel.error) {
+    return <div>Something went wrong. Ensure you have permission to view this team.</div>;
+  }
+
   const isTeamAdmin = teamModel.data?.team.myTeamPermissions.some(
     (p) => p === "Admin"
   );
@@ -29,6 +33,9 @@ const Team: React.FC = () => {
       <BackLinkBar />
       <div className="page-title mb-3">
         <h1>{teamModel.data?.team.name}</h1>
+        <Link to={`/teams/${id}/admins`} className="btn btn-link">
+          View Team Admins
+        </Link>
       </div>
       <div className="mb-3"></div>
       <SearchBar

--- a/Finjector.Web/ClientApp/src/pages/Teams/Team.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/Team.tsx
@@ -7,6 +7,7 @@ import FinLoader from "../../components/Shared/FinLoader";
 import DeleteTeam from "../../components/Teams/DeleteTeam";
 import LeaveTeam from "../../components/Teams/LeaveTeam";
 import { BackLinkBar } from "../../components/Shared/BackLinkBar";
+import { isPersonalOrDefault } from "../../util/teamDefinitions";
 
 const Team: React.FC = () => {
   // get id from url
@@ -21,12 +22,18 @@ const Team: React.FC = () => {
   }
 
   if (teamModel.error) {
-    return <div>Something went wrong. Ensure you have permission to view this team.</div>;
+    return (
+      <div>
+        Something went wrong. Ensure you have permission to view this team.
+      </div>
+    );
   }
 
   const isTeamAdmin = teamModel.data?.team.myTeamPermissions.some(
     (p) => p === "Admin"
   );
+
+  const limitedTeam = isPersonalOrDefault(teamModel.data?.team.name);
 
   return (
     <div>
@@ -48,7 +55,7 @@ const Team: React.FC = () => {
         setSearch={setSearch}
       />
       <div>
-        {isTeamAdmin && (
+        {!limitedTeam && isTeamAdmin && (
           <>
             <Link to={`/teams/${id}/create`} className="btn btn-new me-3">
               Create New Folder
@@ -59,16 +66,16 @@ const Team: React.FC = () => {
             <Link to={`/teams/${id}/permissions`} className="btn btn-new me-3">
               Manage Team Users
             </Link>
+            <DeleteTeam teamId={id} />
           </>
         )}
 
-        {teamModel.data?.team.myTeamPermissions.some((p) => p === "Admin") && (
-          <DeleteTeam teamId={id} />
+        {!limitedTeam && (
+          <LeaveTeam
+            teamId={id}
+            myPermissions={teamModel.data?.team.myTeamPermissions || []}
+          />
         )}
-        <LeaveTeam
-          teamId={id}
-          myPermissions={teamModel.data?.team.myTeamPermissions || []}
-        />
       </div>
       <div className="mb-3">
         <FolderList teamModel={teamModel.data} filter={search} />

--- a/Finjector.Web/ClientApp/src/pages/Teams/UserManagement.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/UserManagement.tsx
@@ -70,11 +70,13 @@ const UserManagement: React.FC = () => {
                 <td>{member.level}</td>
                 <td>{member.roleName}</td>
                 <td>
-                  <RemoveUserPermission
-                    resourceId={resourceId}
-                    resourceType={resourceType}
-                    userEmail={member.userEmail}
-                  />
+                  {resourceType === member.level && (
+                    <RemoveUserPermission
+                      resourceId={resourceId}
+                      resourceType={resourceType}
+                      userEmail={member.userEmail}
+                    />
+                  )}
                 </td>
               </tr>
             ))}

--- a/Finjector.Web/ClientApp/src/pages/Teams/UserManagement.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/UserManagement.tsx
@@ -56,6 +56,7 @@ const UserManagement: React.FC = () => {
           <tr>
             <th>User Name</th>
             <th>User Email</th>
+            <th>Level</th>
             <th>Role Name</th>
             <th>Remove Role</th>
           </tr>
@@ -66,6 +67,7 @@ const UserManagement: React.FC = () => {
               <tr key={member.userEmail}>
                 <td>{member.userName}</td>
                 <td>{member.userEmail}</td>
+                <td>{member.level}</td>
                 <td>{member.roleName}</td>
                 <td>
                   <RemoveUserPermission

--- a/Finjector.Web/ClientApp/src/queries/storedChartQueries.ts
+++ b/Finjector.Web/ClientApp/src/queries/storedChartQueries.ts
@@ -1,12 +1,12 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { Coa, ChartType, AeDetails } from "../types";
+import { Coa, ChartType, AeDetails, TeamGroupedCoas } from "../types";
 import { doFetch } from "../util/api";
 
 // Using query functions here in case we change to async/stored stirngs later
 export const useGetSavedCharts = () =>
   useQuery(["charts", "me"], async () => {
-    const charts = await doFetch<Coa[]>(fetch(`/api/charts/all`));
+    const charts = await doFetch<TeamGroupedCoas[]>(fetch(`/api/charts/all`));
 
     return charts;
   });

--- a/Finjector.Web/ClientApp/src/queries/userQueries.ts
+++ b/Finjector.Web/ClientApp/src/queries/userQueries.ts
@@ -39,6 +39,27 @@ export const usePermissionsQuery = (id: string, type: CollectionResourceType) =>
     }
   );
 
+// fetch admin info for a given team or folder
+export const useAdminsQuery = (id: string, type: CollectionResourceType) =>
+  useQuery(
+    ["users", "admins", type, id],
+    async () => {
+      return await doFetch<PermissionsResponseModel[]>(
+        fetch(`/api/user/admins/${type}/${id}`)
+      );
+    },
+    {
+      retry(failureCount, error: Error) {
+        if (error instanceof Error && error.message.startsWith("401")) {
+          return false;
+        }
+
+        // otherwise retry the normal amount
+        return failureCount < 3;
+      },
+    }
+  );
+
 // new mutation to add a user to a resource
 export const useAddUserMutation = (
   id: string,

--- a/Finjector.Web/ClientApp/src/shared/Header.tsx
+++ b/Finjector.Web/ClientApp/src/shared/Header.tsx
@@ -27,10 +27,10 @@ const Header = () => (
             Charts
           </Link>
           <CenteredBullet />
-          {/*<Link className="header-link" to="/teams">*/}
-          {/*  Teams*/}
-          {/*</Link>*/}
-          {/*<CenteredBullet />*/}
+          <Link className="header-link" to="/teams">
+           Teams
+          </Link>
+          <CenteredBullet />
           <Link className="header-link" to="/about">
             About
           </Link>

--- a/Finjector.Web/ClientApp/src/types.ts
+++ b/Finjector.Web/ClientApp/src/types.ts
@@ -29,6 +29,7 @@ export interface Folder {
   teamName: string;
   myFolderPermissions: PermissionType[];
   myTeamPermissions: PermissionType[];
+  coas: Coa[];
 }
 
 export type CollectionResourceType = "team" | "folder";
@@ -36,6 +37,11 @@ export type CollectionResourceType = "team" | "folder";
 export type PermissionType = "Admin" | "Edit" | "View";
 
 /* ----- Query specific response types ------- */
+
+export interface TeamGroupedCoas {
+  team: Team;
+  folders: Folder[];
+}
 
 export interface NameAndDescriptionModel {
   name: string;

--- a/Finjector.Web/ClientApp/src/types.ts
+++ b/Finjector.Web/ClientApp/src/types.ts
@@ -18,7 +18,7 @@ export interface Team {
   name: string;
   description?: string;
   isPersonal: boolean;
-  myTeamPermissions: string[];
+  myTeamPermissions: PermissionType[];
 }
 
 export interface Folder {
@@ -27,11 +27,13 @@ export interface Folder {
   description?: string;
   teamId: number;
   teamName: string;
-  myFolderPermissions: string[];
-  myTeamPermissions: string[];
+  myFolderPermissions: PermissionType[];
+  myTeamPermissions: PermissionType[];
 }
 
 export type CollectionResourceType = "team" | "folder";
+
+export type PermissionType = "Admin" | "Edit" | "View";
 
 /* ----- Query specific response types ------- */
 
@@ -39,7 +41,6 @@ export interface NameAndDescriptionModel {
   name: string;
   description?: string;
 }
-
 
 export interface TeamsResponseModel {
   team: Team;

--- a/Finjector.Web/ClientApp/src/types.ts
+++ b/Finjector.Web/ClientApp/src/types.ts
@@ -68,6 +68,7 @@ export interface FolderResponseModel {
 }
 
 export interface PermissionsResponseModel {
+  level: string;
   resourceName: string;
   roleName: string;
   userName: string;

--- a/Finjector.Web/ClientApp/src/util/mockData.ts
+++ b/Finjector.Web/ClientApp/src/util/mockData.ts
@@ -1,6 +1,19 @@
-import { Coa, ChartType } from "../types";
+import { Coa, ChartType, Team, Folder } from "../types";
 
 const fakeCharts: Coa[] = [];
+const fakeTeams: Team[] = [];
+const fakeFolders: Folder[] = [];
+
+// make 3 fake teams
+for (let i = 0; i < 3; i++) {
+  fakeTeams.push({
+    id: i,
+    name: `Team ${i}`,
+    description: `Team ${i} description`,
+    isPersonal: false,
+    myTeamPermissions: ["Admin", "Edit", "View"],
+  });
+}
 
 // make 3 fake charts
 for (let i = 0; i < 3; i++) {
@@ -15,4 +28,18 @@ for (let i = 0; i < 3; i++) {
   });
 }
 
-export { fakeCharts };
+// make 3 fake folders
+for (let i = 0; i < 3; i++) {
+  fakeFolders.push({
+    id: i,
+    name: `Folder ${i}`,
+    description: `Folder ${i} description`,
+    teamId: 0,
+    teamName: "Team 0",
+    myFolderPermissions: ["Admin", "Edit", "View"],
+    myTeamPermissions: ["Admin", "Edit", "View"],
+    coas: [...fakeCharts],
+  });
+}
+
+export { fakeCharts, fakeFolders, fakeTeams };

--- a/Finjector.Web/ClientApp/src/util/teamDefinitions.ts
+++ b/Finjector.Web/ClientApp/src/util/teamDefinitions.ts
@@ -1,0 +1,3 @@
+export const isPersonalOrDefault = (name: string | undefined) => {
+  return name === "Personal" || name === "Default";
+};

--- a/Finjector.Web/Controllers/FolderController.cs
+++ b/Finjector.Web/Controllers/FolderController.cs
@@ -47,6 +47,7 @@ namespace Finjector.Web.Controllers
                     MyTeamPermissions = f.Team.TeamPermissions.Where(tp => tp.User.Iam == iamId)
                         .Select(tp => tp.Role.Name),
                 })
+                .AsSplitQuery()
                 .SingleOrDefaultAsync(f => f.Id == id);
 
             var charts = await _dbContext.Coas.Where(c => c.FolderId == id).ToListAsync();

--- a/Finjector.Web/Controllers/TeamController.cs
+++ b/Finjector.Web/Controllers/TeamController.cs
@@ -178,7 +178,7 @@ public class TeamController : ControllerBase
     }
 
     /// <summary>
-    /// remove your permissions from a team.
+    /// remove your permissions from a team AND any folder within that team
     /// If you are the only admin, just soft delete a team by setting IsActive to false
     /// </summary>
     /// <param name="id"></param>
@@ -206,8 +206,13 @@ public class TeamController : ControllerBase
             // otherwise, just remove their permissions
             var teamPermission = await _dbContext.TeamPermissions.Where(tp => tp.TeamId == id && tp.User.Iam == iamId)
                 .ToListAsync();
+            
+            var folderPermissions = await _dbContext.FolderPermissions
+                .Where(fp => fp.Folder.TeamId == id && fp.User.Iam == iamId)
+                .ToListAsync();
 
             _dbContext.TeamPermissions.RemoveRange(teamPermission);
+            _dbContext.FolderPermissions.RemoveRange(folderPermissions);
         }
 
         await _dbContext.SaveChangesAsync();

--- a/Finjector.Web/Controllers/TeamController.cs
+++ b/Finjector.Web/Controllers/TeamController.cs
@@ -66,6 +66,12 @@ public class TeamController : ControllerBase
     public async Task<IActionResult> Get(int id)
     {
         var iamId = Request.GetCurrentUserIamId();
+        
+        // make sure they have permission to view the team
+        if (await _userService.VerifyFolderWithinTeamAccess(id, iamId, Role.Codes.View) == false)
+        {
+            return Unauthorized();
+        }
 
         var team = await _dbContext.Teams
             .Select(t => new

--- a/Finjector.Web/Controllers/UserController.cs
+++ b/Finjector.Web/Controllers/UserController.cs
@@ -114,7 +114,7 @@ public class UserController : ControllerBase
                 .ToArrayAsync();
 
             var permissions = teamPermissions.Concat(folderPermissions)
-                .OrderBy(p => p.UserName).ThenBy(p => p.Level).ToArray();
+                .OrderBy(p => p.Level).ThenBy(p => p.UserName).ToArray();
 
             return Ok(permissions);
         }

--- a/Finjector.Web/Controllers/UserController.cs
+++ b/Finjector.Web/Controllers/UserController.cs
@@ -119,6 +119,83 @@ public class UserController : ControllerBase
             return Ok(permissions);
         }
     }
+    
+    /// <summary>
+    /// get the admins for a given resource. Can be accessed by anyone who can view the resource, unlike permissions
+    /// NOTE: if folder, returns permissions for the containing team as well, using the "level" discriminator
+    /// </summary>
+    /// <param name="type">string value `team` or `folder`. If not "team" defaults to folder.</param>
+    /// <param name="id">ID of the team of folder</param>
+    /// <returns></returns>
+    [HttpGet("admins/{type}/{id}")]
+    public async Task<IActionResult> Admins(string type, int id)
+    {
+        var iamId = _httpContextAccessor.HttpContext?.Request.GetCurrentUserIamId();
+
+        if (string.IsNullOrWhiteSpace(iamId))
+        {
+            return Unauthorized();
+        }
+
+        var canViewAdmins = await CanViewAdmins(type, id, iamId);
+
+        if (!canViewAdmins)
+        {
+            return Unauthorized();
+        }
+
+        if (type == TeamResourceType)
+        {
+            var teamPermissions = await _dbContext.TeamPermissions
+                .Where(tp => tp.TeamId == id)
+                .Select(tp => new PermissionsModel
+                {
+                    Level = "team",
+                    RoleName = tp.Role.Name,
+                    ResourceName = tp.Team.Name,
+                    UserName = tp.User.Name,
+                    UserEmail = tp.User.Email
+                })
+                .AsNoTracking()
+                .ToArrayAsync();
+
+            return Ok(teamPermissions);
+        }
+        else
+        {
+            var teamPermissions = await _dbContext.Folders
+                .Where(folder => folder.Id == id)
+                .SelectMany(f => f.Team.TeamPermissions)
+                .Select(tp => new PermissionsModel
+                {
+                    Level = "team",
+                    RoleName = tp.Role.Name,
+                    ResourceName = tp.Team.Name,
+                    UserName = tp.User.Name,
+                    UserEmail = tp.User.Email
+                })
+                .AsNoTracking()
+                .ToArrayAsync();
+
+            var folderPermissions = await _dbContext.FolderPermissions
+                .Where(fp => fp.FolderId == id)
+                .Select(fp => new PermissionsModel
+                {
+                    Level = "folder",
+                    RoleName = fp.Role.Name,
+                    ResourceName = fp.Folder.Name,
+                    UserName = fp.User.Name,
+                    UserEmail = fp.User.Email
+                })
+                .AsNoTracking()
+                .ToArrayAsync();
+
+            var permissions = teamPermissions.Concat(folderPermissions)
+                .OrderBy(p => p.Level).ThenBy(p => p.UserName).ToArray();
+
+            return Ok(permissions);
+        }
+    }
 
     /// <summary>
     /// add a permission to a given resource
@@ -296,6 +373,21 @@ public class UserController : ControllerBase
             ? await _userService.VerifyTeamAccess(id, iamId, Role.Codes.Admin)
             : await _userService.VerifyFolderAccess(id, iamId, Role.Codes.Admin);
         return hasAdminPermissions;
+    }
+    
+    /// <summary>
+    /// anyone with a role can view admins, even if they only have a role in a subfolder
+    /// </summary>
+    /// <param name="type">team of folder</param>
+    /// <param name="id">id of resource</param>
+    /// <param name="iamId">iam of user</param>
+    /// <returns></returns>
+    private async Task<bool> CanViewAdmins(string type, int id, string iamId)
+    {
+        var access = string.Equals(TeamResourceType, type, StringComparison.OrdinalIgnoreCase)
+            ? await _userService.VerifyFolderWithinTeamAccess(id, iamId, Role.Codes.View)
+            : await _userService.VerifyFolderAccess(id, iamId, Role.Codes.View);
+        return access;
     }
 }
 


### PR DESCRIPTION
* Biggest change is that landing page now includes team and folder info for each chart. 
* Permissions changes so that you can only view the correct buttons on team and folder pages
* new page to view team or folder admins, linked from team/folder detail pages
* user management now includes "level" and will show team roles on folder pages
* update leave team to remove your sub folder permissions 

closes #136 except i didn't make admins on myteams clickable.  i didn't like the look of it, can approach differently later.  I didn't do the team/folder update yet since i was just focusing on that issue, but that can be the next PR.