### PR TITLE
Fix how we count folders, coas and members on team pages

### DIFF
--- a/Finjector.Web/ClientApp/src/components/Teams/FolderList.tsx
+++ b/Finjector.Web/ClientApp/src/components/Teams/FolderList.tsx
@@ -43,7 +43,7 @@ const FolderList = (props: Props) => {
             <div className="col-3 d-flex justify-content-end">
               <div className="stat-icon">
                 <FontAwesomeIcon icon={faUsers} />
-                {folderInfo.folderMemberCount}
+                {folderInfo.uniqueUserPermissionCount}
               </div>
               <div className="stat-icon">
                 <FontAwesomeIcon icon={faDollarSign} />

--- a/Finjector.Web/ClientApp/src/components/Teams/TeamList.tsx
+++ b/Finjector.Web/ClientApp/src/components/Teams/TeamList.tsx
@@ -51,7 +51,7 @@ const ChartList = (props: Props) => {
               </div>
               <div className="stat-icon">
                 <FontAwesomeIcon icon={faUsers} />
-                {teamInfo.teamPermissionCount + teamInfo.folderPermissionCount}
+                {teamInfo.uniqueUserPermissionCount}
               </div>
               <div className="stat-icon">
                 <FontAwesomeIcon icon={faDollarSign} />

--- a/Finjector.Web/ClientApp/src/types.ts
+++ b/Finjector.Web/ClientApp/src/types.ts
@@ -51,8 +51,7 @@ export interface NameAndDescriptionModel {
 export interface TeamsResponseModel {
   team: Team;
   folderCount: number;
-  teamPermissionCount: number;
-  folderPermissionCount: number;
+  uniqueUserPermissionCount: number;
   chartCount: number;
   admins: string[];
 }

--- a/Finjector.Web/ClientApp/src/types.ts
+++ b/Finjector.Web/ClientApp/src/types.ts
@@ -62,7 +62,7 @@ export interface TeamResponseModel {
     {
       folder: Folder;
       chartCount: number;
-      folderMemberCount: number;
+      uniqueUserPermissionCount: number;
     }
   ];
 }

--- a/Finjector.Web/Controllers/TeamController.cs
+++ b/Finjector.Web/Controllers/TeamController.cs
@@ -48,6 +48,7 @@ public class TeamController : ControllerBase
                 },
                 FolderCount = t.Folders.AsQueryable().Count(folderCondition),
                 Admins = t.TeamPermissions.Select(p => p.User.FirstName + " " + p.User.LastName),
+                // select permissions for team plus all folders within that team
                 UniqueUserPermissionCount = t.TeamPermissions.Select(p => p.UserId)
                     .Union(t.Folders.AsQueryable().Where(folderCondition)
                         .SelectMany(f => f.FolderPermissions.Select(p => p.UserId))).Distinct().Count(),
@@ -102,8 +103,10 @@ public class TeamController : ControllerBase
             {
                 Folder = f.Key,
                 ChartCount = f.SelectMany(c => c.Coas).Count(),
-                FolderMemberCount =
-                    f.SelectMany(c => c.FolderPermissions).Count(),
+                // select permissions for folder plus team
+                UniqueUserPermissionCount = f.SelectMany(c => c.Team.TeamPermissions.Select(t => t.UserId).Union(c.FolderPermissions.Select(p => p.UserId))).Distinct()
+                    .Count(),
+                
             })
             .ToListAsync();
 

--- a/Finjector.Web/Extensions/QueryExtensions.cs
+++ b/Finjector.Web/Extensions/QueryExtensions.cs
@@ -1,0 +1,12 @@
+using System.Linq.Expressions;
+using Finjector.Core.Domain;
+
+namespace Finjector.Web.Extensions;
+
+public static class QueryExtensions
+{
+    public static Func<string, Expression<Func<Folder, bool>>> GetFolderCondition = (iamId) => (f =>
+            f.FolderPermissions.Any(fp => fp.User.Iam == iamId) || 
+            f.Team.TeamPermissions.Any(tp => tp.User.Iam == iamId)
+        );
+}


### PR DESCRIPTION
New slightly more complex rules for getting the counts when viewing all teams or one team:
1. Folder count for a team is only count of folders you can see, not all team folders.
2. Member count for a team is anyone who has team-level permissions AND anyone who has folder-level permissions for any folder you can see.  
3. Similarly, member count for folder includes members who only have access to the covering team
4. count of COAs only includes COAs in folders you have access to.

closes #134