### PR TITLE
Apply global filters to entities with effected navigations

### DIFF
--- a/Finjector.Core/Domain/Folder.cs
+++ b/Finjector.Core/Domain/Folder.cs
@@ -38,6 +38,8 @@ namespace Finjector.Core.Domain
         internal static void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<Folder>().HasQueryFilter(t => t.IsActive);
+            modelBuilder.Entity<Coa>().HasQueryFilter(c => c.Folder.IsActive);
+            modelBuilder.Entity<FolderPermission>().HasQueryFilter(fp => fp.Folder.IsActive);
 
             modelBuilder.Entity<Coa>()
                 .HasOne(a => a.Folder)

--- a/Finjector.Core/Domain/Team.cs
+++ b/Finjector.Core/Domain/Team.cs
@@ -43,6 +43,9 @@ namespace Finjector.Core.Domain
         internal static void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<Team>().HasQueryFilter(t => t.IsActive);
+            modelBuilder.Entity<Folder>().HasQueryFilter(f => f.Team.IsActive);
+            modelBuilder.Entity<TeamPermission>().HasQueryFilter(tp => tp.Team.IsActive);
+            modelBuilder.Entity<History>().HasQueryFilter(h => h.Team.IsActive);
             
             modelBuilder.Entity<Folder>()
                 .HasOne(a => a.Team)


### PR DESCRIPTION
Any time we create a global filter, we need to define equivalent global filters for any entities with required (as in foreign key is not nullable) navigation properties pointing to that entity. For bool `IsActive` flags, this is pretty straight forward. The warnings are gone. I'm not too familiar with recent changes, so you may want to do some of your own testing before this is merged.