### PR TITLE
Clear out folder id if can't edit

### DIFF
--- a/Finjector.Web/Controllers/ChartsController.cs
+++ b/Finjector.Web/Controllers/ChartsController.cs
@@ -50,6 +50,10 @@ public class ChartsController : ControllerBase
                return NotFound();
         }
         rtValue.CanEdit = await _userService.VerifyChartAccess(id, iamId, Role.Codes.Edit);
+        if(!rtValue.CanEdit)
+        {
+            rtValue.FolderId = 0;
+        }
 
         return Ok(rtValue);
     }


### PR DESCRIPTION
But keep the folder so can display the folder name This fixes the issue where clicking the duplicate button without touching the folder search doesn't save