### PR TITLE
Rh/create chartstring in folder

### DIFF
--- a/Finjector.Web/ClientApp/src/App.tsx
+++ b/Finjector.Web/ClientApp/src/App.tsx
@@ -139,6 +139,11 @@ const router = createBrowserRouter([
                     handle: { title: "Entry", hideBreadcrumbs: true },
                   },
                   {
+                    path: "entry/",
+                    element: <Entry />,
+                    handle: { title: "Entry", hideBreadcrumbs: false },
+                  },
+                  {
                     path: "selected/:chartId/:chartSegmentString",
                     element: <Selected />,
                     handle: { title: "Selected" },

--- a/Finjector.Web/ClientApp/src/App.tsx
+++ b/Finjector.Web/ClientApp/src/App.tsx
@@ -139,7 +139,7 @@ const router = createBrowserRouter([
                     handle: { title: "Entry", hideBreadcrumbs: true },
                   },
                   {
-                    path: "entry/",
+                    path: "entry/", // when creating from folder
                     element: <Entry />,
                     handle: { title: "Entry", hideBreadcrumbs: false },
                   },

--- a/Finjector.Web/ClientApp/src/components/Entry/FolderSearch.tsx
+++ b/Finjector.Web/ClientApp/src/components/Entry/FolderSearch.tsx
@@ -121,6 +121,17 @@ const FolderSearch = ({
           }}
         />
       </InputGroup>
+      <div className="row mb-5">
+        <div className="col-md-6">
+          {data && (
+            <div className="form-text">
+              Current Team: {selectedFolder?.teamName}
+              <br />
+              Current Folder: {selectedFolder?.name}
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   );
 };

--- a/Finjector.Web/ClientApp/src/components/Entry/FolderSearch.tsx
+++ b/Finjector.Web/ClientApp/src/components/Entry/FolderSearch.tsx
@@ -15,11 +15,13 @@ import { InputGroup, InputGroupText } from "reactstrap";
 interface FolderSearchProps {
   updateFolderId: (folderId: number) => void;
   selectedFolderId?: number;
+  disabled?: boolean;
 }
 
 const FolderSearch = ({
   updateFolderId,
   selectedFolderId,
+  disabled,
 }: FolderSearchProps) => {
   const [selectedFolder, setSelectedFolder] = useState<Folder | undefined>();
 
@@ -61,8 +63,8 @@ const FolderSearch = ({
     <div className="col-md-6">
       <h2>Folder</h2>
       <p>Choose where you would like to store your chart string</p>
-      <InputGroup>
-        <InputGroupText>
+      <InputGroup aria-disabled={disabled}>
+        <InputGroupText aria-disabled={disabled}>
           {selectedFolder?.teamName ?? "Personal"}
         </InputGroupText>
         <Typeahead
@@ -76,6 +78,7 @@ const FolderSearch = ({
           onChange={handleSelected}
           options={data || []} // data
           clearButton={true}
+          disabled={disabled}
           renderMenu={(
             results,
             {

--- a/Finjector.Web/ClientApp/src/components/Entry/FolderSearch.tsx
+++ b/Finjector.Web/ClientApp/src/components/Entry/FolderSearch.tsx
@@ -16,12 +16,15 @@ interface FolderSearchProps {
   updateFolderId: (folderId: number) => void;
   selectedFolderId?: number;
   disabled?: boolean;
+  // where the chart is currently saved (this will not change when the user selects a new folder from the input)
+  currentlySavedInFolderId?: number;
 }
 
 const FolderSearch = ({
   updateFolderId,
   selectedFolderId,
   disabled,
+  currentlySavedInFolderId,
 }: FolderSearchProps) => {
   const [selectedFolder, setSelectedFolder] = useState<Folder | undefined>();
 
@@ -62,7 +65,7 @@ const FolderSearch = ({
   };
 
   return (
-    <div className="col-md-6">
+    <>
       <h2>Folder</h2>
       <p>Choose where you would like to store your chart string</p>
       <InputGroup aria-disabled={disabled}>
@@ -123,18 +126,16 @@ const FolderSearch = ({
           }}
         />
       </InputGroup>
-      <div className="row mb-5">
-        <div className="col-md-6">
-          <div className="form-text">
-            Current Team:{" "}
-            {query.isFetched && (selectedFolder?.teamName ?? "Personal")}
-            <br />
-            Current Folder:{" "}
-            {query.isFetched && (selectedFolder?.name ?? "Default")}
-          </div>
+      {currentlySavedInFolderId && (
+        <div className="form-text">
+          Current Team:{" "}
+          {query.data?.find((f) => f.id === currentlySavedInFolderId)?.teamName}
+          <br />
+          Current Folder:{" "}
+          {query.data?.find((f) => f.id === currentlySavedInFolderId)?.name}
         </div>
-      </div>
-    </div>
+      )}
+    </>
   );
 };
 

--- a/Finjector.Web/ClientApp/src/components/Entry/NameEntry.tsx
+++ b/Finjector.Web/ClientApp/src/components/Entry/NameEntry.tsx
@@ -10,22 +10,20 @@ interface Props {
 const NameEntry = (props: Props) => {
   return (
     <>
-      <div className="col-md-6">
-        <h2>Name</h2>
-        <div className="chart-type">
-          <form>
-            <p>Give your chart string a name to remember it by</p>
-            <Input
-              required
-              type="text"
-              className="form-control"
-              valid={props.chart.name.length > 0}
-              invalid={props.chart.name.length === 0}
-              value={props.chart.name}
-              onChange={(e) => props.updateName(e.target.value)}
-            />
-          </form>
-        </div>
+      <h2>Name</h2>
+      <div className="chart-type">
+        <form>
+          <p>Give your chart string a name to remember it by</p>
+          <Input
+            required
+            type="text"
+            className="form-control"
+            valid={props.chart.name.length > 0}
+            invalid={props.chart.name.length === 0}
+            value={props.chart.name}
+            onChange={(e) => props.updateName(e.target.value)}
+          />
+        </form>
       </div>
     </>
   );

--- a/Finjector.Web/ClientApp/src/pages/Entry.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Entry.tsx
@@ -163,7 +163,7 @@ const Entry = () => {
         <hr />
         <div className="row">
           <FolderSearch
-            disabled={saveInFolderId !== 0} // if we came from a folder, lock it
+            disabled={saveInFolderId !== 0 && !chartSegmentString && !chartId} // if are creating from Folder, lock it (not on edit)
             selectedFolderId={savedChart.folderId}
             updateFolderId={(folderId) =>
               setSavedChart((c) => ({ ...c, folderId }))

--- a/Finjector.Web/ClientApp/src/pages/Entry.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Entry.tsx
@@ -162,19 +162,23 @@ const Entry = () => {
         <CoaDisplay chartData={chartData} />
         <hr />
         <div className="row">
-          <FolderSearch
-            disabled={saveInFolderId !== 0 && !chartSegmentString && !chartId} // if are creating from Folder, lock it (not on edit)
-            selectedFolderId={savedChart.folderId}
-            updateFolderId={(folderId) =>
-              setSavedChart((c) => ({ ...c, folderId }))
-            }
-          />
-          <NameEntry
-            chart={savedChart}
-            updateName={(n) => setSavedChart((c) => ({ ...c, name: n }))}
-          />
+          <div className="col-md-6 mb-3">
+            <FolderSearch
+              disabled={saveInFolderId !== 0 && !chartSegmentString && !chartId} // if are creating from Folder, lock it (not on edit)
+              selectedFolderId={savedChart.folderId}
+              updateFolderId={(folderId) =>
+                setSavedChart((c) => ({ ...c, folderId }))
+              }
+              currentlySavedInFolderId={savedChartQuery.data?.chart.folderId}
+            />
+          </div>
+          <div className="col-md-6 mb-3">
+            <NameEntry
+              chart={savedChart}
+              updateName={(n) => setSavedChart((c) => ({ ...c, name: n }))}
+            />
+          </div>
         </div>
-
         {savedChart.id ? (
           <EntryEditButtons chartData={chartData} savedChart={savedChart} />
         ) : (

--- a/Finjector.Web/ClientApp/src/pages/Entry.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Entry.tsx
@@ -163,6 +163,7 @@ const Entry = () => {
         <hr />
         <div className="row">
           <FolderSearch
+            disabled={saveInFolderId !== 0} // if we came from a folder, lock it
             selectedFolderId={savedChart.folderId}
             updateFolderId={(folderId) =>
               setSavedChart((c) => ({ ...c, folderId }))

--- a/Finjector.Web/ClientApp/src/pages/Entry.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Entry.tsx
@@ -175,18 +175,6 @@ const Entry = () => {
           />
         </div>
 
-        <div className="row mb-5">
-          <div className="col-md-6">
-            {savedChartQuery.data && (
-              <div className="form-text">
-                Current Team: {savedChartQuery.data.chart.teamName}
-                <br />
-                Current Folder: {savedChartQuery.data.chart.folder?.name}
-              </div>
-            )}
-          </div>
-        </div>
-
         {savedChart.id ? (
           <EntryEditButtons chartData={chartData} savedChart={savedChart} />
         ) : (

--- a/Finjector.Web/ClientApp/src/pages/Entry.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Entry.tsx
@@ -34,11 +34,8 @@ import { ChartLoadingError } from "../components/Shared/ChartLoadingError";
 import FolderSearch from "../components/Entry/FolderSearch";
 
 const Entry = () => {
-  const { chartId, chartSegmentString } = useParams();
-  const [searchParams] = useSearchParams();
-  const saveInFolderId = searchParams?.get("folderId")
-    ? parseInt(searchParams.get("folderId") || "")
-    : 0;
+  const { chartId, chartSegmentString, folderId } = useParams();
+  const saveInFolderId = parseInt(folderId ?? "0");
 
   const savedChartQuery = useGetSavedChartWithData(chartId || "");
 

--- a/Finjector.Web/ClientApp/src/pages/Teams/Folder.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Teams/Folder.tsx
@@ -66,7 +66,7 @@ const Folder: React.FC = () => {
           {/* Editors & above can create new chart strings */}
           {combinedPermissions.some((p) => p === "Admin" || p === "Edit") && (
             <FinjectorButton
-              to={`/entry?folderId=${folderModel.data?.folder.id}`}
+              to={`/teams/${teamId}/folders/${folderModel.data?.folder.id}/entry`}
             >
               <FontAwesomeIcon icon={faPlus} />
               New Chart String Here

--- a/Finjector.Web/ClientApp/src/sass/_components.scss
+++ b/Finjector.Web/ClientApp/src/sass/_components.scss
@@ -170,6 +170,9 @@ hr {
   border: 1px solid $borders;
   color: $primary-font;
 }
+.form-control:disabled {
+  margin-left: 1px;
+}
 .form-control:focus {
   background-color: $primary-bg;
   border-color: $primary-color;


### PR DESCRIPTION
when creating a chart string inside a folder, uses new routing to get folderId instead of passing as a query parameter. also disables the input 
closes #212
closes #267 

![Screen Recording 2024-01-12 at 2 14 21 PM](https://github.com/ucdavis/finjector/assets/27025973/acf3ab56-92de-4419-9819-ff7de5a6dd39)
