### PR TITLE
populate name with full text match if found

### DIFF
--- a/Finjector.Web/ClientApp/src/components/Entry/SegmentSearch.tsx
+++ b/Finjector.Web/ClientApp/src/components/Entry/SegmentSearch.tsx
@@ -11,6 +11,24 @@ interface Props {
   minQueryLength?: number;
 }
 
+export function getSegmentNameDisplay(
+  segmentData: SegmentData,
+  segmentQueryData: SegmentData[] | undefined
+): string {
+  if (segmentQueryData) {
+    const segment = segmentQueryData.find(
+      (s: any) => s.code === segmentData.code
+    );
+    if (segment) {
+      return segment.name;
+    } else {
+      return `${segmentData.segmentName} not selected`;
+    }
+  } else {
+    return segmentData.name || `${segmentData.segmentName} not selected`;
+  }
+}
+
 const SegmentSearch = (props: Props) => {
   const minQueryLength = props.minQueryLength || 3;
 
@@ -48,6 +66,11 @@ const SegmentSearch = (props: Props) => {
     }
   };
 
+  const segmentNameDisplay = React.useMemo(
+    () => getSegmentNameDisplay(props.segmentData, segmentQuery.data),
+    [props.segmentData, segmentQuery.data]
+  );
+
   // notes: this async typeahead will be configured a little differently than normal, since we want to bind the text values at all times
   // 1. our query will handle caching, so turn off the cache or we won't get full results
   // 2. onSearch is request but we don't really need it, so watch as the input changes to reset the segment data
@@ -76,10 +99,7 @@ const SegmentSearch = (props: Props) => {
           </>
         )}
       />
-      <div className="form-text">
-        {props.segmentData.name ||
-          `${props.segmentData.segmentName} not selected`}
-      </div>
+      <div className="form-text">{segmentNameDisplay}</div>
     </div>
   );
 };

--- a/Finjector.Web/ClientApp/src/components/Entry/TaskSelector.tsx
+++ b/Finjector.Web/ClientApp/src/components/Entry/TaskSelector.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { Typeahead } from "react-bootstrap-typeahead";
 import { useTaskQuery } from "../../queries/segmentQueries";
 import { SegmentData } from "../../types";
+import { getSegmentNameDisplay } from "./SegmentSearch";
 
 interface Props {
   segmentData: SegmentData; // task segment
@@ -48,6 +49,11 @@ const TaskSelector = (props: Props) => {
     }
   };
 
+  const segmentNameDisplay = React.useMemo(
+    () => getSegmentNameDisplay(props.segmentData, taskQuery.data),
+    [props.segmentData, taskQuery.data]
+  );
+
   return (
     <div className="mb-3 col-sm-6">
       <label className="form-label">Task</label>
@@ -67,10 +73,7 @@ const TaskSelector = (props: Props) => {
           </>
         )}
       />
-      <div className="form-text">
-        {props.segmentData.name ||
-          `${props.segmentData.segmentName} not selected`}
-      </div>
+      <div className="form-text">{segmentNameDisplay}</div>
     </div>
   );
 };


### PR DESCRIPTION
PPM doesn't return segment names during validation, while GL does.  I was going to do an extra query to pull back PPM names, but I realized that we are already querying names for each field, so instead I wrote a little helper so that whenever we get back the list of available options, if we match one of those options just pull the detail name from there.  seems to work well.

closes #56
