### PR TITLE
have dropdown show status of search

### DIFF
--- a/Finjector.Web/ClientApp/src/components/Entry/SegmentSearch.tsx
+++ b/Finjector.Web/ClientApp/src/components/Entry/SegmentSearch.tsx
@@ -93,9 +93,9 @@ const SegmentSearch = (props: Props) => {
         promptText={
           segmentQuery.isFetching
             ? "Searching..."
-            : !segmentQuery.data
-            ? "Type to search..."
-            : "No matches found."
+            : !!segmentQuery.data && segmentQuery.data.length === 0
+            ? "No matches found."
+            : "Type to search..."
         }
         onInputChange={handleInputChange}
         defaultInputValue={props.segmentData.code}

--- a/Finjector.Web/ClientApp/src/components/Entry/SegmentSearch.tsx
+++ b/Finjector.Web/ClientApp/src/components/Entry/SegmentSearch.tsx
@@ -88,8 +88,15 @@ const SegmentSearch = (props: Props) => {
         filterBy={() => true} // don't filter since we're doing it on the server
         isLoading={segmentQuery.isFetching}
         labelKey="code"
-        minLength={minQueryLength}
+        minLength={0} // to show "Type to search" before the user has started typing, we have to set minLength to 0. however, useSegmentQuery won't do anything until it meets minLength
         onSearch={() => {}}
+        promptText={
+          segmentQuery.isFetching
+            ? "Searching..."
+            : !segmentQuery.data
+            ? "Type to search..."
+            : "No matches found."
+        }
         onInputChange={handleInputChange}
         defaultInputValue={props.segmentData.code}
         onChange={handleSelected}


### PR DESCRIPTION
![Screen Recording 2024-02-27 at 2 36 15 PM](https://github.com/ucdavis/finjector/assets/27025973/9023b48a-e68c-41d4-87fc-097f8eef6657)

previously just showed this after you started typing–so really on searching or no results you saw "type to search" 
![image](https://github.com/ucdavis/finjector/assets/27025973/85b81c56-01be-4564-babc-a3b2e49ccb5d)
