### PR TITLE
Add gift and endowment fund badges to chart details

### DIFF
--- a/Finjector.Core/Finjector.Core.csproj
+++ b/Finjector.Core/Finjector.Core.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AggieEnterpriseApi" Version="0.3.14" />
+    <PackageReference Include="AggieEnterpriseApi" Version="0.3.17" />
     <PackageReference Include="ietws" Version="0.2.26" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">

--- a/Finjector.Core/Models/AeDetails.cs
+++ b/Finjector.Core/Models/AeDetails.cs
@@ -58,6 +58,8 @@ namespace Finjector.Core.Models
         public string? Entity { get; set; } = string.Empty;
         public string? Code { get; set; } = string.Empty;
         public string? Name { get; set; } = string.Empty;
+        public bool GiftFund { get; set; }
+        public bool EndowmentGiftFund { get; set; }
     }
 
     public class Approver

--- a/Finjector.Core/Models/SearchResult.cs
+++ b/Finjector.Core/Models/SearchResult.cs
@@ -2,15 +2,13 @@ namespace Finjector.Core.Models
 {
     public class SearchResult
     {
-        public SearchResult(string code, string name, string? fundPurpose = null)
+        public SearchResult(string code, string name)
         {
             Code = code;
             Name = name;
-            FundPurpose = fundPurpose;
         }
 
         public string Code { get; set; }
         public string Name { get; set; }
-        public string? FundPurpose { get; set; }
     }
 }

--- a/Finjector.Core/Services/AggieEnterpriseService.cs
+++ b/Finjector.Core/Services/AggieEnterpriseService.cs
@@ -218,7 +218,9 @@ namespace Finjector.Core.Services
                 Order = 2,
                 Entity = "Fund",
                 Code = data.ErpFund?.Code ?? glSegments.Fund,
-                Name = data.ErpFund?.Name
+                Name = data.ErpFund?.Name,
+                GiftFund = data.ErpFund?.GiftFund ?? false,
+                EndowmentGiftFund = data.ErpFund?.EndowmentGiftFund ?? false,
             });
             aeDetails.SegmentDetails.Add(new SegmentDetails
             {
@@ -443,13 +445,7 @@ namespace Finjector.Core.Services
                             Entity = "GL Fund",
                             Code = awardResult.GlFundCode,
                         };
-                        var fundResult = await Fund(segment.Code);
-                        var fundData = fundResult.Where(a => a.Code == segment.Code).FirstOrDefault();
-                        if (fundData != null)
-                        {
-                            segment.Name = fundData.Name;
-                            SetFundPurpose(aeDetails, fundData.FundPurpose);
-                        }
+                        await SetPpmFundDetails(aeDetails, segment);
 
                         aeDetails.SegmentDetails.Add(segment);
                     }
@@ -523,13 +519,7 @@ namespace Finjector.Core.Services
                     Entity = "GL Posting Fund",
                     Code = data.PpmTaskByProjectNumberAndTaskNumber.GlPostingFundCode,
                 };
-                var fundResult = await Fund(segment.Code);
-                var fundData = fundResult.Where(a => a.Code == segment.Code).FirstOrDefault();
-                if (fundData != null)
-                {
-                    segment.Name = fundData.Name;
-                    SetFundPurpose(aeDetails, fundData.FundPurpose);
-                }
+                await SetPpmFundDetails(aeDetails, segment);
                 aeDetails.SegmentDetails.Add(segment);
             }
             if (data.PpmTaskByProjectNumberAndTaskNumber?.GlPostingPurposeCode != null)
@@ -686,6 +676,26 @@ namespace Finjector.Core.Services
                 aeDetails.FundPurpose = fundPurpose;
             }
         }
+
+        private async Task SetPpmFundDetails(AeDetails aeDetails, SegmentDetails segment)
+        {
+            if (string.IsNullOrWhiteSpace(segment.Code))
+            {
+                return;
+            }
+
+            var result = await _apiClient.FundDetails.ExecuteAsync(segment.Code);
+            var data = result.ReadData();
+            if (data?.ErpFund == null)
+            {
+                return;
+            }
+
+            segment.Name = data.ErpFund.Name;
+            segment.GiftFund = data.ErpFund.GiftFund;
+            segment.EndowmentGiftFund = data.ErpFund.EndowmentGiftFund;
+            SetFundPurpose(aeDetails, data.ErpFund.FundPurpose);
+        }
         
         public FinancialChartStringType GetChartType(string segmentString)
         {
@@ -715,11 +725,11 @@ namespace Finjector.Core.Services
             var data = result.ReadData();
 
             var searchResults = data.ErpFundSearch.Data.Where(a => a.EligibleForUse)
-                .Select(d => new SearchResult(d.Code, d.Name, d.FundPurpose));
+                .Select(d => new SearchResult(d.Code, d.Name));
 
             if (data.ErpFund is { EligibleForUse: true })
             {
-                searchResults = searchResults.Append(new SearchResult(data.ErpFund.Code, data.ErpFund.Name, data.ErpFund.FundPurpose));
+                searchResults = searchResults.Append(new SearchResult(data.ErpFund.Code, data.ErpFund.Name));
             }
 
             return searchResults.DistinctBy(p => p.Code);

--- a/Finjector.Web/ClientApp/src/components/Details/DetailsRow.tsx
+++ b/Finjector.Web/ClientApp/src/components/Details/DetailsRow.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 interface DetailsRowProps extends React.HTMLAttributes<HTMLDivElement> {
-  headerColText: string | null;
+  headerColText: React.ReactNode;
   column2: React.ReactNode;
   column3?: React.ReactNode;
 }

--- a/Finjector.Web/ClientApp/src/components/Details/DetailsTable.tsx
+++ b/Finjector.Web/ClientApp/src/components/Details/DetailsTable.tsx
@@ -45,13 +45,34 @@ const DetailsTable: React.FC<DetailsBodyProps> = ({
     );
   }
 
+  const renderSegmentHeader = (segment: AeDetails["segmentDetails"][number]) => {
+    const showFundBadges =
+      (aeDetails.chartType === ChartType.GL && segment.entity === "Fund") ||
+      (aeDetails.chartType === ChartType.PPM &&
+        segment.entity === "GL Posting Fund");
+
+    if (!showFundBadges || (!segment.giftFund && !segment.endowmentGiftFund)) {
+      return segment.entity;
+    }
+
+    return (
+      <span className="d-inline-flex align-items-center gap-2 flex-wrap">
+        <span>{segment.entity}</span>
+        {segment.giftFund && <span className="badge bg-primary">Gift</span>}
+        {segment.endowmentGiftFund && (
+          <span className="badge bg-secondary">Endowment</span>
+        )}
+      </span>
+    );
+  };
+
   return (
     <>
       <div className="chartstring-details-info unique-bg">
         {aeDetails.segmentDetails.map((segment, i) => {
           return (
             <DetailsRow
-              headerColText={segment.entity}
+              headerColText={renderSegmentHeader(segment)}
               key={i}
               column2={
                 <span className="fw-bold primary-font me-4">

--- a/Finjector.Web/ClientApp/src/pages/Details.test.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Details.test.tsx
@@ -105,6 +105,7 @@ describe("Details", () => {
     });
 
     expect(screen.getByText("Gift")).toBeInTheDocument();
+    expect(screen.queryByText("Endowment")).not.toBeInTheDocument();
   });
 });
 

--- a/Finjector.Web/ClientApp/src/pages/Details.test.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Details.test.tsx
@@ -8,6 +8,7 @@ import { server } from "../../test/mocks/node";
 import {
   fakeCharts,
   fakeInvalidChart,
+  fakePpmChart,
   fakeValidAeDetails,
   fakeValidChart,
 } from "../../test/mocks/mockData";
@@ -85,6 +86,25 @@ describe("Details", () => {
     expect(
       screen.getByText(fakeValidAeDetails.fundPurpose || "")
     ).toBeInTheDocument();
+  });
+  it("shows gift badges after the GL fund label", async () => {
+    render(wrappedView(fakeValidChart.segmentString));
+
+    await waitFor(() => {
+      expect(screen.getByText("Fund")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Gift")).toBeInTheDocument();
+    expect(screen.getByText("Endowment")).toBeInTheDocument();
+  });
+  it("shows gift badges after the PPM GL posting fund label", async () => {
+    render(wrappedView(fakePpmChart.segmentString));
+
+    await waitFor(() => {
+      expect(screen.getByText("GL Posting Fund")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Gift")).toBeInTheDocument();
   });
 });
 

--- a/Finjector.Web/ClientApp/src/types.ts
+++ b/Finjector.Web/ClientApp/src/types.ts
@@ -193,6 +193,8 @@ export interface SegmentDetails {
   entity: string | null;
   code: string | null;
   name: string | null;
+  giftFund?: boolean;
+  endowmentGiftFund?: boolean;
 }
 
 export interface Approver {

--- a/Finjector.Web/ClientApp/test/mocks/handlers.ts
+++ b/Finjector.Web/ClientApp/test/mocks/handlers.ts
@@ -3,6 +3,8 @@ import {
   fakeTeams,
   fakeFolders,
   fakeInvalidAeDetails,
+  fakePpmAeDetails,
+  fakePpmChart,
   fakeValidChart,
   fakeValidAeDetails,
   fakeCharts,
@@ -30,6 +32,9 @@ export const handlers = [
 
     if (segmentString === fakeValidChart.segmentString) {
       aeDetailsToUse = fakeValidAeDetails;
+    }
+    if (segmentString === fakePpmChart.segmentString) {
+      aeDetailsToUse = fakePpmAeDetails;
     }
 
     return HttpResponse.json({

--- a/Finjector.Web/ClientApp/test/mocks/mockData.ts
+++ b/Finjector.Web/ClientApp/test/mocks/mockData.ts
@@ -324,6 +324,7 @@ const fakePpmDetails: PpmDetails = {
 // let's just assign the first chart to be valid and the second to be invalid
 const fakeValidChart = { ...fakeCharts[0] };
 const fakeInvalidChart = { ...fakeCharts[1] };
+const fakePpmChart = { ...fakeCharts[3] };
 
 const fakeInvalidAeDetails: AeDetails = {
   isValid: false,
@@ -441,6 +442,8 @@ const fakeValidAeDetails: AeDetails = {
       entity: "Fund",
       code: "73830",
       name: null,
+      giftFund: true,
+      endowmentGiftFund: true,
     },
     {
       order: 3,
@@ -518,11 +521,37 @@ const fakeValidAeDetails: AeDetails = {
   hasWarnings: false,
 };
 
+const fakePpmAeDetails: AeDetails = {
+  ...fakeValidAeDetails,
+  chartType: "PPM",
+  chartString: fakePpmChart.segmentString,
+  chartStringType: ChartType.PPM,
+  segmentDetails: [
+    {
+      order: 10,
+      entity: "Project",
+      code: "KL0733ATC1",
+      name: "Fake PPM Project",
+    },
+    {
+      order: 100,
+      entity: "GL Posting Fund",
+      code: "73830",
+      name: "Fake Posting Fund",
+      giftFund: true,
+      endowmentGiftFund: false,
+    },
+  ],
+  ppmDetails: fakePpmDetails,
+};
+
 export {
   fakeCharts,
   fakeFolders,
   fakeTeams,
   fakePpmDetails,
+  fakePpmChart,
+  fakePpmAeDetails,
   fakeValidChart,
   fakeInvalidChart,
   fakeInvalidAeDetails,

--- a/Finjector.Web/Finjector.Web.csproj
+++ b/Finjector.Web/Finjector.Web.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AggieEnterpriseApi" Version="0.3.14" />
+    <PackageReference Include="AggieEnterpriseApi" Version="0.3.17" />
     <PackageReference Include="Ietws" Version="0.2.26" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="10.0.5" />


### PR DESCRIPTION
Updates Aggie Enterprise API to leverage new `GiftFund` and `EndowmentGiftFund` properties. This information is now displayed as badges next to Fund (GL) and GL Posting Fund (PPM) segments on the chart details page.

Refactors fund detail retrieval for PPM segments to use the new `FundDetails` API endpoint and consistently populate these new properties, as well as `FundPurpose`. The `FundPurpose` property was removed from `SearchResult` as it is now retrieved directly via `FundDetails`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added visual badges showing Gift Fund and Endowment Gift Fund on Details pages for clearer fund classification.

* **Bug Fixes**
  * Fund search results no longer display deprecated fund-purpose text (search results simplified).

* **UI**
  * Segment headers now support richer content rendering for improved header display.

* **Tests**
  * Added UI tests validating badge behavior.

* **Chores**
  * Updated AggieEnterpriseApi dependency to v0.3.17.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/finjector/pull/396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->