### PR TITLE
Display PPM Project GL posting entity in details

### DIFF
--- a/Finjector.Core/Finjector.Core.csproj
+++ b/Finjector.Core/Finjector.Core.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AggieEnterpriseApi" Version="0.3.17" />
+    <PackageReference Include="AggieEnterpriseApi" Version="0.3.19" />
     <PackageReference Include="ietws" Version="0.2.26" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">

--- a/Finjector.Core/Models/AeDetails.cs
+++ b/Finjector.Core/Models/AeDetails.cs
@@ -92,6 +92,9 @@ namespace Finjector.Core.Models
         public string? ProjectCompletionDate { get; set; } = string.Empty;
 
         public string? ProjectStatus { get; set; } = string.Empty;
+
+        public string? ProjectEntity { get; set; } = string.Empty;
+
         public string? AwardStatus { get; set; } = string.Empty;
         public string? AwardStartDate { get; set; } = string.Empty;
         public string? AwardEndDate { get; set; } = string.Empty;

--- a/Finjector.Core/Services/AggieEnterpriseService.cs
+++ b/Finjector.Core/Services/AggieEnterpriseService.cs
@@ -396,6 +396,23 @@ namespace Finjector.Core.Services
                 }
                 aeDetails.SegmentDetails.Add(segment);
             }
+
+            if (!string.IsNullOrWhiteSpace(data.PpmProjectByNumber?.GlPostingEntityCode))
+            {
+                var segment = new SegmentDetails
+                {
+                    Order = 71,
+                    Entity = "PPM Project Entity",
+                    Code = data.PpmProjectByNumber.GlPostingEntityCode,
+                };
+                var entityResult = await Entity(segment.Code);
+                var entityData = entityResult.Where(a => a.Code == segment.Code).FirstOrDefault();
+                if (entityData != null)
+                {
+                    segment.Name = entityData.Name;
+                }
+                aeDetails.SegmentDetails.Add(segment);
+            }
         }
 
         private async Task SetAwardSpecificPpmGlInfo(AeDetails aeDetails, IDisplayDetailsPpmResult data)

--- a/Finjector.Core/Services/AggieEnterpriseService.cs
+++ b/Finjector.Core/Services/AggieEnterpriseService.cs
@@ -380,29 +380,30 @@ namespace Finjector.Core.Services
                 });
             }
 
-            if (data.PpmProjectByNumber?.LegalEntityCode != null)
-            {
-                var segment = new SegmentDetails
-                {
-                    Order = 70,
-                    Entity = "GL Entity",
-                    Code = data.PpmProjectByNumber.LegalEntityCode,
-                };
-                var entityResult = await Entity(segment.Code);
-                var entityData = entityResult.Where(a => a.Code == segment.Code).FirstOrDefault();
-                if (entityData != null)
-                {
-                    segment.Name = entityData.Name;
-                }
-                aeDetails.SegmentDetails.Add(segment);
-            }
+            //Legal entity wasn't the correct one. We will display that as a Project Entity below.
+            //if (data.PpmProjectByNumber?.LegalEntityCode != null)
+            //{
+            //    var segment = new SegmentDetails
+            //    {
+            //        Order = 70,
+            //        Entity = "GL Entity",
+            //        Code = data.PpmProjectByNumber.LegalEntityCode,
+            //    };
+            //    var entityResult = await Entity(segment.Code);
+            //    var entityData = entityResult.Where(a => a.Code == segment.Code).FirstOrDefault();
+            //    if (entityData != null)
+            //    {
+            //        segment.Name = entityData.Name;
+            //    }
+            //    aeDetails.SegmentDetails.Add(segment);
+            //}
 
             if (!string.IsNullOrWhiteSpace(data.PpmProjectByNumber?.GlPostingEntityCode))
             {
                 var segment = new SegmentDetails
                 {
-                    Order = 71,
-                    Entity = "PPM Project Entity",
+                    Order = 70,
+                    Entity = "GL Entity",
                     Code = data.PpmProjectByNumber.GlPostingEntityCode,
                 };
                 var entityResult = await Entity(segment.Code);
@@ -643,6 +644,7 @@ namespace Finjector.Core.Services
                 aeDetails.PpmDetails.ProjectCompletionDate = data.PpmProjectByNumber.ProjectCompletionDate;
                 aeDetails.PpmDetails.ProjectStatus = data.PpmProjectByNumber.ProjectStatus;
                 aeDetails.PpmDetails.ProjectTypeName = data.PpmProjectByNumber.ProjectTypeName;
+                aeDetails.PpmDetails.ProjectEntity = data.PpmProjectByNumber.LegalEntityCode;
             }
             aeDetails.PpmDetails.PoetString = $"{ppmSegments?.Project}-{ppmSegments?.Organization}-{ppmSegments?.ExpenditureType}-{ppmSegments?.Task}-{data.PpmSegmentStringValidate.Segments.Award ?? "0000000"}-{data.PpmSegmentStringValidate.Segments.FundingSource ?? "00000"}";
 

--- a/Finjector.Web/ClientApp/src/components/Details/PpmDetails.tsx
+++ b/Finjector.Web/ClientApp/src/components/Details/PpmDetails.tsx
@@ -83,15 +83,15 @@ const PpmDetailsPage: React.FC<PpmDetailsProps> = ({ details }) => {
           </CopyToClipboardHover>
         }
       />
-      {details.awardStartDate && (
+      {details.projectEntity && (
         <DetailsRow
-          headerColText="Award Start Date"
+          headerColText="Project Entity"
           column2={
             <CopyToClipboardHover
-              value={details.awardStartDate}
-              id="awardStartDate"
+              value={details.projectEntity}
+              id="projectEntity"
             >
-              {details.awardStartDate}
+              {details.projectEntity}
             </CopyToClipboardHover>
           }
         />

--- a/Finjector.Web/ClientApp/src/components/Details/PpmDetails.tsx
+++ b/Finjector.Web/ClientApp/src/components/Details/PpmDetails.tsx
@@ -96,6 +96,19 @@ const PpmDetailsPage: React.FC<PpmDetailsProps> = ({ details }) => {
           }
         />
       )}
+      {details.awardStartDate && (
+        <DetailsRow
+          headerColText="Award Start Date"
+          column2={
+            <CopyToClipboardHover
+              value={details.awardStartDate}
+              id="awardStartDate"
+            >
+              {details.awardStartDate}
+            </CopyToClipboardHover>
+          }
+        />
+      )}
       {details.awardEndDate && (
         <DetailsRow
           headerColText="Award End Date"

--- a/Finjector.Web/ClientApp/src/pages/Details.test.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Details.test.tsx
@@ -107,6 +107,16 @@ describe("Details", () => {
     expect(screen.getByText("Gift")).toBeInTheDocument();
     expect(screen.queryByText("Endowment")).not.toBeInTheDocument();
   });
+  it("shows PPM project entity under GL entity", async () => {
+    render(wrappedView(fakePpmChart.segmentString));
+
+    await waitFor(() => {
+      expect(screen.getByText("PPM Project Entity")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("3120")).toBeInTheDocument();
+    expect(screen.getByText("UC Davis Health")).toBeInTheDocument();
+  });
 });
 
 const wrappedView = (segmentString: string) => (

--- a/Finjector.Web/ClientApp/src/pages/Details.test.tsx
+++ b/Finjector.Web/ClientApp/src/pages/Details.test.tsx
@@ -107,16 +107,6 @@ describe("Details", () => {
     expect(screen.getByText("Gift")).toBeInTheDocument();
     expect(screen.queryByText("Endowment")).not.toBeInTheDocument();
   });
-  it("shows PPM project entity under GL entity", async () => {
-    render(wrappedView(fakePpmChart.segmentString));
-
-    await waitFor(() => {
-      expect(screen.getByText("PPM Project Entity")).toBeInTheDocument();
-    });
-
-    expect(screen.getByText("3120")).toBeInTheDocument();
-    expect(screen.getByText("UC Davis Health")).toBeInTheDocument();
-  });
 });
 
 const wrappedView = (segmentString: string) => (

--- a/Finjector.Web/ClientApp/src/types.ts
+++ b/Finjector.Web/ClientApp/src/types.ts
@@ -174,7 +174,7 @@ export interface PpmDetails {
   projectStartDate: string;
   projectCompletionDate: string;
   projectStatus: string;
-  projectEntity: string;
+  projectEntity?: string | null;
   awardStatus?: string;
   awardInfo?: string;
   awardStartDate?: string;

--- a/Finjector.Web/ClientApp/src/types.ts
+++ b/Finjector.Web/ClientApp/src/types.ts
@@ -174,6 +174,7 @@ export interface PpmDetails {
   projectStartDate: string;
   projectCompletionDate: string;
   projectStatus: string;
+  projectEntity: string;
   awardStatus?: string;
   awardInfo?: string;
   awardStartDate?: string;

--- a/Finjector.Web/ClientApp/test/mocks/mockData.ts
+++ b/Finjector.Web/ClientApp/test/mocks/mockData.ts
@@ -534,6 +534,18 @@ const fakePpmAeDetails: AeDetails = {
       name: "Fake PPM Project",
     },
     {
+      order: 70,
+      entity: "GL Entity",
+      code: "3110",
+      name: "UC Davis Campus",
+    },
+    {
+      order: 71,
+      entity: "PPM Project Entity",
+      code: "3120",
+      name: "UC Davis Health",
+    },
+    {
       order: 100,
       entity: "GL Posting Fund",
       code: "73830",

--- a/Finjector.Web/ClientApp/test/mocks/mockData.ts
+++ b/Finjector.Web/ClientApp/test/mocks/mockData.ts
@@ -540,12 +540,6 @@ const fakePpmAeDetails: AeDetails = {
       name: "UC Davis Campus",
     },
     {
-      order: 71,
-      entity: "PPM Project Entity",
-      code: "3120",
-      name: "UC Davis Health",
-    },
-    {
       order: 100,
       entity: "GL Posting Fund",
       code: "73830",

--- a/Finjector.Web/Finjector.Web.csproj
+++ b/Finjector.Web/Finjector.Web.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AggieEnterpriseApi" Version="0.3.17" />
+    <PackageReference Include="AggieEnterpriseApi" Version="0.3.19" />
     <PackageReference Include="Ietws" Version="0.2.26" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="10.0.5" />


### PR DESCRIPTION
Enhances the chart string details by including the GL posting entity specifically for PPM Projects. This information is fetched via the Aggie Enterprise API and displayed as a new segment.

Also updates the AggieEnterpriseApi NuGet package to version 0.3.19.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PPM Project Entity now appears in project details (code and resolved name) with a copy-to-clipboard control for easy copying.

* **Tests**
  * Added a UI test to verify the PPM Project Entity is displayed with expected values.

* **Chores**
  * Updated package dependencies to newer compatible versions for improved stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/finjector/pull/398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->