### PR TITLE
Remove commented-out PPM Legal Entity GL segment logic

### DIFF
--- a/Finjector.Core/Services/AggieEnterpriseService.cs
+++ b/Finjector.Core/Services/AggieEnterpriseService.cs
@@ -381,23 +381,6 @@ namespace Finjector.Core.Services
             }
 
             //Legal entity wasn't the correct one. We will display that as a Project Entity below.
-            //if (data.PpmProjectByNumber?.LegalEntityCode != null)
-            //{
-            //    var segment = new SegmentDetails
-            //    {
-            //        Order = 70,
-            //        Entity = "GL Entity",
-            //        Code = data.PpmProjectByNumber.LegalEntityCode,
-            //    };
-            //    var entityResult = await Entity(segment.Code);
-            //    var entityData = entityResult.Where(a => a.Code == segment.Code).FirstOrDefault();
-            //    if (entityData != null)
-            //    {
-            //        segment.Name = entityData.Name;
-            //    }
-            //    aeDetails.SegmentDetails.Add(segment);
-            //}
-
             if (!string.IsNullOrWhiteSpace(data.PpmProjectByNumber?.GlPostingEntityCode))
             {
                 var segment = new SegmentDetails


### PR DESCRIPTION
This removes a block of commented-out code that previously attempted to display the `PpmProjectByNumber.LegalEntityCode` as a 'GL Entity' segment. This logic is no longer relevant as the `GlPostingEntityCode` is now correctly used for the GL entity, and the `LegalEntityCode` has been handled separately or removed in prior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated GL Entity segment population to use GL Posting Entity Code for improved accuracy in enterprise data mapping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/finjector/pull/399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->