### PR TITLE
Remove Project Entity field from PPM details

### DIFF
--- a/Finjector.Core/Models/AeDetails.cs
+++ b/Finjector.Core/Models/AeDetails.cs
@@ -93,8 +93,6 @@ namespace Finjector.Core.Models
 
         public string? ProjectStatus { get; set; } = string.Empty;
 
-        public string? ProjectEntity { get; set; } = string.Empty;
-
         public string? AwardStatus { get; set; } = string.Empty;
         public string? AwardStartDate { get; set; } = string.Empty;
         public string? AwardEndDate { get; set; } = string.Empty;

--- a/Finjector.Core/Services/AggieEnterpriseService.cs
+++ b/Finjector.Core/Services/AggieEnterpriseService.cs
@@ -380,7 +380,6 @@ namespace Finjector.Core.Services
                 });
             }
 
-            //Legal entity wasn't the correct one. We will display that as a Project Entity below.
             if (!string.IsNullOrWhiteSpace(data.PpmProjectByNumber?.GlPostingEntityCode))
             {
                 var segment = new SegmentDetails
@@ -627,7 +626,6 @@ namespace Finjector.Core.Services
                 aeDetails.PpmDetails.ProjectCompletionDate = data.PpmProjectByNumber.ProjectCompletionDate;
                 aeDetails.PpmDetails.ProjectStatus = data.PpmProjectByNumber.ProjectStatus;
                 aeDetails.PpmDetails.ProjectTypeName = data.PpmProjectByNumber.ProjectTypeName;
-                aeDetails.PpmDetails.ProjectEntity = data.PpmProjectByNumber.LegalEntityCode;
             }
             aeDetails.PpmDetails.PoetString = $"{ppmSegments?.Project}-{ppmSegments?.Organization}-{ppmSegments?.ExpenditureType}-{ppmSegments?.Task}-{data.PpmSegmentStringValidate.Segments.Award ?? "0000000"}-{data.PpmSegmentStringValidate.Segments.FundingSource ?? "00000"}";
 

--- a/Finjector.Web/ClientApp/src/components/Details/PpmDetails.tsx
+++ b/Finjector.Web/ClientApp/src/components/Details/PpmDetails.tsx
@@ -83,19 +83,6 @@ const PpmDetailsPage: React.FC<PpmDetailsProps> = ({ details }) => {
           </CopyToClipboardHover>
         }
       />
-      {details.projectEntity && (
-        <DetailsRow
-          headerColText="Project Entity"
-          column2={
-            <CopyToClipboardHover
-              value={details.projectEntity}
-              id="projectEntity"
-            >
-              {details.projectEntity}
-            </CopyToClipboardHover>
-          }
-        />
-      )}
       {details.awardStartDate && (
         <DetailsRow
           headerColText="Award Start Date"

--- a/Finjector.Web/ClientApp/src/types.ts
+++ b/Finjector.Web/ClientApp/src/types.ts
@@ -174,7 +174,6 @@ export interface PpmDetails {
   projectStartDate: string;
   projectCompletionDate: string;
   projectStatus: string;
-  projectEntity?: string | null;
   awardStatus?: string;
   awardInfo?: string;
   awardStartDate?: string;


### PR DESCRIPTION
The `ProjectEntity` field was incorrectly populated with the legal entity code, which caused confusion. This change removes the field and its associated display logic to simplify the data model and user interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed the Project Entity field from PPM details display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/finjector/pull/400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->