### PR TITLE
Feat: Adjust chart list padding for popup selection

### DIFF
--- a/Finjector.Web/ClientApp/src/components/Folders/ChartListSimple.tsx
+++ b/Finjector.Web/ClientApp/src/components/Folders/ChartListSimple.tsx
@@ -4,6 +4,7 @@ import ChartListItem from "../Shared/ChartListItem";
 import { useFinQueryStatusHandler } from "../../util/error";
 import FinEmpty from "../Shared/LoadingAndErrors/FinEmpty";
 import FinFunError from "../Shared/LoadingAndErrors/FinFunError";
+import usePopupStatus from "../../util/customHooks";
 
 interface Props {
   charts: Coa[] | undefined;
@@ -29,6 +30,7 @@ const ChartListSimple: React.FC<Props> = ({
   const queryStatusComponent = useFinQueryStatusHandler({
     queryStatus,
   });
+  const isInPopup = usePopupStatus();
   const selectVisibleCheckboxRef = React.useRef<HTMLInputElement>(null);
   const filterLowercase = filter.toLowerCase();
 
@@ -72,7 +74,11 @@ const ChartListSimple: React.FC<Props> = ({
   };
 
   return (
-    <>
+    <div
+      className={`chartstring-list${isInPopup ? " is-in-popup" : ""}${
+        canSelectChartStrings ? " has-selection" : ""
+      }`}
+    >
       {canSelectChartStrings && (
         <div className="chartstring-selection-toggle">
           <input
@@ -97,7 +103,7 @@ const ChartListSimple: React.FC<Props> = ({
           />
         ))}
       </ul>
-    </>
+    </div>
   );
 };
 

--- a/Finjector.Web/ClientApp/src/sass/_regions.scss
+++ b/Finjector.Web/ClientApp/src/sass/_regions.scss
@@ -125,6 +125,9 @@
     margin: -8px 0 -8px -8px;
   }
 }
+.chartstring-list.is-in-popup.has-selection {
+  padding-left: 42px;
+}
 .fin-row {
   border-radius: 4px;
   border: 1px solid $borders !important;


### PR DESCRIPTION
Applies specific padding to the chart string list when it is displayed within a popup and has multi-selection enabled. This ensures adequate space for selection checkboxes, preventing layout issues and improving usability in popup contexts.